### PR TITLE
fix(P2,A1): patient self-edit profile + admin edit user details

### DIFF
--- a/backend/src/routes/patients.js
+++ b/backend/src/routes/patients.js
@@ -16,6 +16,28 @@ router.get('/:id', async (req, res) => {
     }
 });
 
+// PATCH /api/patients/:id — update editable profile fields
+router.patch('/:id', async (req, res) => {
+    try {
+        const { first_name, last_name, phone, address, blood_group } = req.body;
+        await db.query(
+            `UPDATE patients SET
+                first_name  = COALESCE(?, first_name),
+                last_name   = COALESCE(?, last_name),
+                phone       = COALESCE(?, phone),
+                address     = COALESCE(?, address),
+                blood_group = COALESCE(?, blood_group)
+             WHERE id = ?`,
+            [first_name ?? null, last_name ?? null, phone ?? null, address ?? null, blood_group ?? null, req.params.id]
+        );
+        const [rows] = await db.query('SELECT * FROM patients p JOIN users u ON p.id = u.id WHERE p.id = ?', [req.params.id]);
+        res.json(rows[0]);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Get a patient's appointments
 router.get('/:id/appointments', async (req, res) => {
     try {

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -1,17 +1,22 @@
 import React, { useState, useEffect } from 'react';
-import { Plus, Trash2, Stethoscope, Users, X } from 'lucide-react';
+import { Plus, Trash2, X, Pencil } from 'lucide-react';
+import { API } from '../config/api';
+
+const inputClass = "w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary";
 
 const AdminUsers = () => {
     const [users, setUsers] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
-    const [showForm, setShowForm] = useState(null); // 'doctor' | 'patient' | null
+    const [showForm, setShowForm] = useState(null); // 'doctor' | 'patient' | 'edit' | null
     const [formData, setFormData] = useState({});
+    const [editId, setEditId] = useState(null);
+    const [editRole, setEditRole] = useState(null);
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState('');
     const [filterRole, setFilterRole] = useState('ALL');
 
     const fetchUsers = () => {
-        fetch('http://localhost:5001/api/admin/users')
+        fetch(`${API}/api/admin/users`)
             .then(res => res.json())
             .then(data => setUsers(data))
             .catch(err => console.error(err))
@@ -24,35 +29,54 @@ const AdminUsers = () => {
         if (!confirm(`Are you sure you want to remove this ${role.toLowerCase()}? This will also delete all their appointments.`)) return;
         const endpoint = role === 'DOCTOR' ? `/api/admin/doctors/${id}` : `/api/admin/patients/${id}`;
         try {
-            await fetch(`http://localhost:5001${endpoint}`, { method: 'DELETE' });
+            await fetch(`${API}${endpoint}`, { method: 'DELETE' });
             setUsers(prev => prev.filter(u => u.id !== id));
         } catch (err) {
             console.error(err);
         }
     };
 
+    const handleEdit = async (id, role) => {
+        setError('');
+        const url = role === 'DOCTOR' ? `${API}/api/doctors/${id}` : `${API}/api/patients/${id}`;
+        const res = await fetch(url);
+        const data = await res.json();
+        setFormData({
+            first_name: data.first_name || '',
+            last_name: data.last_name || '',
+            specialty: data.specialty || '',
+            degree: data.degree || '',
+            experience_years: data.experience_years || '',
+            location_room: data.location_room || '',
+            phone: data.phone || '',
+            address: data.address || '',
+            blood_group: data.blood_group || '',
+        });
+        setEditId(id);
+        setEditRole(role);
+        setShowForm('edit');
+    };
+
     const handleFormChange = e => setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }));
+
+    const closeModal = () => { setShowForm(null); setFormData({}); setError(''); setEditId(null); setEditRole(null); };
 
     const handleSubmitDoctor = async (e) => {
         e.preventDefault();
         setError('');
         setSubmitting(true);
         try {
-            const res = await fetch('http://localhost:5001/api/admin/doctors', {
+            const res = await fetch(`${API}/api/admin/doctors`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)
             });
             const data = await res.json();
             if (!res.ok) { setError(data.message); return; }
-            setShowForm(null);
-            setFormData({});
+            closeModal();
             fetchUsers();
-        } catch (err) {
-            setError('Server error');
-        } finally {
-            setSubmitting(false);
-        }
+        } catch { setError('Server error'); }
+        finally { setSubmitting(false); }
     };
 
     const handleSubmitPatient = async (e) => {
@@ -60,21 +84,37 @@ const AdminUsers = () => {
         setError('');
         setSubmitting(true);
         try {
-            const res = await fetch('http://localhost:5001/api/admin/patients', {
+            const res = await fetch(`${API}/api/admin/patients`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)
             });
             const data = await res.json();
             if (!res.ok) { setError(data.message); return; }
-            setShowForm(null);
-            setFormData({});
+            closeModal();
             fetchUsers();
-        } catch (err) {
-            setError('Server error');
-        } finally {
-            setSubmitting(false);
-        }
+        } catch { setError('Server error'); }
+        finally { setSubmitting(false); }
+    };
+
+    const handleSubmitEdit = async (e) => {
+        e.preventDefault();
+        setError('');
+        setSubmitting(true);
+        try {
+            const url = editRole === 'DOCTOR'
+                ? `${API}/api/doctors/${editId}`
+                : `${API}/api/patients/${editId}`;
+            const res = await fetch(url, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(formData)
+            });
+            if (!res.ok) { const d = await res.json(); setError(d.message); return; }
+            closeModal();
+            fetchUsers();
+        } catch { setError('Server error'); }
+        finally { setSubmitting(false); }
     };
 
     const filtered = filterRole === 'ALL' ? users : users.filter(u => u.role === filterRole);
@@ -84,7 +124,7 @@ const AdminUsers = () => {
             <div className="flex justify-between items-center">
                 <div>
                     <h1 className="text-2xl font-bold text-gray-900">Manage Users</h1>
-                    <p className="text-gray-500 mt-1">Add or remove doctors and patients.</p>
+                    <p className="text-gray-500 mt-1">Add, edit, or remove doctors and patients.</p>
                 </div>
                 <div className="flex gap-3">
                     <button onClick={() => { setShowForm('doctor'); setFormData({}); setError(''); }} className="flex items-center gap-2 px-4 py-2.5 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors text-sm">
@@ -96,100 +136,92 @@ const AdminUsers = () => {
                 </div>
             </div>
 
-            {/* Modal form */}
+            {/* Modal */}
             {showForm && (
                 <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
-                    <div className="bg-white rounded-3xl shadow-2xl w-full max-w-lg p-8 relative">
-                        <button onClick={() => setShowForm(null)} className="absolute top-4 right-4 p-2 hover:bg-gray-100 rounded-xl">
+                    <div className="bg-white rounded-3xl shadow-2xl w-full max-w-lg p-8 relative max-h-[90vh] overflow-y-auto">
+                        <button onClick={closeModal} className="absolute top-4 right-4 p-2 hover:bg-gray-100 rounded-xl">
                             <X size={18} />
                         </button>
                         <h2 className="text-xl font-bold text-gray-900 mb-6">
-                            {showForm === 'doctor' ? 'Add New Doctor' : 'Add New Patient'}
+                            {showForm === 'edit'
+                                ? `Edit ${editRole === 'DOCTOR' ? 'Doctor' : 'Patient'}`
+                                : showForm === 'doctor' ? 'Add New Doctor' : 'Add New Patient'}
                         </h2>
                         {error && <p className="mb-4 p-3 bg-red-50 text-red-700 rounded-lg text-sm">{error}</p>}
 
-                        {showForm === 'doctor' ? (
-                            <form onSubmit={handleSubmitDoctor} className="space-y-4">
+                        {/* Edit doctor */}
+                        {showForm === 'edit' && editRole === 'DOCTOR' && (
+                            <form onSubmit={handleSubmitEdit} className="space-y-4">
                                 <div className="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">First Name</label>
-                                        <input name="first_name" required value={formData.first_name || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Last Name</label>
-                                        <input name="last_name" required value={formData.last_name || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div className="col-span-2">
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Email</label>
-                                        <input name="email" type="email" required value={formData.email || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div className="col-span-2">
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Password</label>
-                                        <input name="password" type="password" required value={formData.password || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Specialty</label>
-                                        <input name="specialty" required value={formData.specialty || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Degree</label>
-                                        <input name="degree" value={formData.degree || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Experience (years)</label>
-                                        <input name="experience_years" type="number" value={formData.experience_years || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Room / Location</label>
-                                        <input name="location_room" value={formData.location_room || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">First Name</label><input name="first_name" value={formData.first_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Last Name</label><input name="last_name" value={formData.last_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Specialty</label><input name="specialty" value={formData.specialty || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Degree</label><input name="degree" value={formData.degree || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Experience (years)</label><input name="experience_years" type="number" value={formData.experience_years || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Room / Location</label><input name="location_room" value={formData.location_room || ''} onChange={handleFormChange} className={inputClass} /></div>
                                 </div>
-                                <button type="submit" disabled={submitting} className="w-full py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-60">
-                                    {submitting ? 'Adding...' : 'Add Doctor'}
-                                </button>
+                                <button type="submit" disabled={submitting} className="w-full py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-60">{submitting ? 'Saving...' : 'Save Changes'}</button>
                             </form>
-                        ) : (
-                            <form onSubmit={handleSubmitPatient} className="space-y-4">
+                        )}
+
+                        {/* Edit patient */}
+                        {showForm === 'edit' && editRole === 'PATIENT' && (
+                            <form onSubmit={handleSubmitEdit} className="space-y-4">
                                 <div className="grid grid-cols-2 gap-4">
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">First Name</label>
-                                        <input name="first_name" required value={formData.first_name || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Last Name</label>
-                                        <input name="last_name" required value={formData.last_name || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div className="col-span-2">
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Email</label>
-                                        <input name="email" type="email" required value={formData.email || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div className="col-span-2">
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Password</label>
-                                        <input name="password" type="password" required value={formData.password || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Date of Birth</label>
-                                        <input name="dob" type="date" value={formData.dob || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">First Name</label><input name="first_name" value={formData.first_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Last Name</label><input name="last_name" value={formData.last_name || ''} onChange={handleFormChange} className={inputClass} /></div>
                                     <div>
                                         <label className="block text-xs font-semibold text-gray-600 mb-1">Blood Group</label>
-                                        <select name="blood_group" value={formData.blood_group || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary">
+                                        <select name="blood_group" value={formData.blood_group || ''} onChange={handleFormChange} className={inputClass}>
                                             <option value="">Select</option>
                                             {['A+','A-','B+','B-','AB+','AB-','O+','O-'].map(bg => <option key={bg} value={bg}>{bg}</option>)}
                                         </select>
                                     </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Phone</label>
-                                        <input name="phone" value={formData.phone || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
-                                    <div>
-                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Address</label>
-                                        <input name="address" value={formData.address || ''} onChange={handleFormChange} className="w-full border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary" />
-                                    </div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Phone</label><input name="phone" value={formData.phone || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div className="col-span-2"><label className="block text-xs font-semibold text-gray-600 mb-1">Address</label><input name="address" value={formData.address || ''} onChange={handleFormChange} className={inputClass} /></div>
                                 </div>
-                                <button type="submit" disabled={submitting} className="w-full py-3 bg-primary text-white font-semibold rounded-xl hover:bg-primary-hover transition-colors disabled:opacity-60">
-                                    {submitting ? 'Adding...' : 'Add Patient'}
-                                </button>
+                                <button type="submit" disabled={submitting} className="w-full py-3 bg-primary text-white font-semibold rounded-xl hover:bg-primary-hover transition-colors disabled:opacity-60">{submitting ? 'Saving...' : 'Save Changes'}</button>
+                            </form>
+                        )}
+
+                        {/* Add doctor */}
+                        {showForm === 'doctor' && (
+                            <form onSubmit={handleSubmitDoctor} className="space-y-4">
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">First Name</label><input name="first_name" required value={formData.first_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Last Name</label><input name="last_name" required value={formData.last_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div className="col-span-2"><label className="block text-xs font-semibold text-gray-600 mb-1">Email</label><input name="email" type="email" required value={formData.email || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div className="col-span-2"><label className="block text-xs font-semibold text-gray-600 mb-1">Password</label><input name="password" type="password" required value={formData.password || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Specialty</label><input name="specialty" required value={formData.specialty || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Degree</label><input name="degree" value={formData.degree || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Experience (years)</label><input name="experience_years" type="number" value={formData.experience_years || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Room / Location</label><input name="location_room" value={formData.location_room || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                </div>
+                                <button type="submit" disabled={submitting} className="w-full py-3 bg-blue-600 text-white font-semibold rounded-xl hover:bg-blue-700 transition-colors disabled:opacity-60">{submitting ? 'Adding...' : 'Add Doctor'}</button>
+                            </form>
+                        )}
+
+                        {/* Add patient */}
+                        {showForm === 'patient' && (
+                            <form onSubmit={handleSubmitPatient} className="space-y-4">
+                                <div className="grid grid-cols-2 gap-4">
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">First Name</label><input name="first_name" required value={formData.first_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Last Name</label><input name="last_name" required value={formData.last_name || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div className="col-span-2"><label className="block text-xs font-semibold text-gray-600 mb-1">Email</label><input name="email" type="email" required value={formData.email || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div className="col-span-2"><label className="block text-xs font-semibold text-gray-600 mb-1">Password</label><input name="password" type="password" required value={formData.password || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Date of Birth</label><input name="dob" type="date" value={formData.dob || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div>
+                                        <label className="block text-xs font-semibold text-gray-600 mb-1">Blood Group</label>
+                                        <select name="blood_group" value={formData.blood_group || ''} onChange={handleFormChange} className={inputClass}>
+                                            <option value="">Select</option>
+                                            {['A+','A-','B+','B-','AB+','AB-','O+','O-'].map(bg => <option key={bg} value={bg}>{bg}</option>)}
+                                        </select>
+                                    </div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Phone</label><input name="phone" value={formData.phone || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                    <div><label className="block text-xs font-semibold text-gray-600 mb-1">Address</label><input name="address" value={formData.address || ''} onChange={handleFormChange} className={inputClass} /></div>
+                                </div>
+                                <button type="submit" disabled={submitting} className="w-full py-3 bg-primary text-white font-semibold rounded-xl hover:bg-primary-hover transition-colors disabled:opacity-60">{submitting ? 'Adding...' : 'Add Patient'}</button>
                             </form>
                         )}
                     </div>
@@ -243,14 +275,18 @@ const AdminUsers = () => {
                                         {u.role === 'PATIENT' && <span className="text-red-500 font-medium">{u.blood_group}</span>}
                                     </td>
                                     <td className="px-6 py-4 text-right">
-                                        {u.role !== 'ADMIN' && (
-                                            <button
-                                                onClick={() => handleDelete(u.id, u.role)}
-                                                className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors"
-                                            >
-                                                <Trash2 size={16} />
-                                            </button>
-                                        )}
+                                        <div className="flex items-center justify-end gap-1">
+                                            {u.role !== 'ADMIN' && (
+                                                <button onClick={() => handleEdit(u.id, u.role)} className="p-2 text-gray-400 hover:text-primary hover:bg-primary-light rounded-lg transition-colors" title="Edit">
+                                                    <Pencil size={15} />
+                                                </button>
+                                            )}
+                                            {u.role !== 'ADMIN' && (
+                                                <button onClick={() => handleDelete(u.id, u.role)} className="p-2 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-lg transition-colors" title="Delete">
+                                                    <Trash2 size={15} />
+                                                </button>
+                                            )}
+                                        </div>
                                     </td>
                                 </tr>
                             ))}

--- a/frontend/src/pages/PatientProfile.jsx
+++ b/frontend/src/pages/PatientProfile.jsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { User, Phone, Mail, MapPin, Shield, CreditCard, Bell, Settings } from 'lucide-react';
+import { User, Phone, Mail, MapPin, Shield, CreditCard, Bell, Settings, Save, X } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { API } from '../config/api';
+
+const BLOOD_GROUPS = ['A+', 'A-', 'B+', 'B-', 'AB+', 'AB-', 'O+', 'O-'];
+
+const inputClass = "w-full border border-gray-200 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary bg-white";
 
 const ProfileMenu = ({ icon: Icon, title, description, isActive }) => (
     <button className={`w-full flex items-center gap-4 p-4 rounded-2xl transition-all ${isActive
@@ -18,12 +23,16 @@ const ProfileMenu = ({ icon: Icon, title, description, isActive }) => (
 );
 
 const PatientProfile = () => {
-    const { user } = useAuth();
+    const { user, login } = useAuth();
     const [profile, setProfile] = useState(null);
+    const [isEditing, setIsEditing] = useState(false);
+    const [form, setForm] = useState({});
+    const [saving, setSaving] = useState(false);
+    const [saveMsg, setSaveMsg] = useState(null); // {type:'success'|'error', text}
 
     useEffect(() => {
         if (!user?.id) return;
-        fetch(`http://localhost:5001/api/patients/${user.id}`)
+        fetch(`${API}/api/patients/${user.id}`)
             .then(res => res.json())
             .then(data => setProfile(data))
             .catch(err => console.error(err));
@@ -39,6 +48,55 @@ const PatientProfile = () => {
         const age = new Date().getFullYear() - d.getFullYear();
         return `${d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })} (${age} Yrs)`;
     };
+
+    const startEdit = () => {
+        setForm({
+            first_name:  profile?.first_name  || '',
+            last_name:   profile?.last_name   || '',
+            phone:       profile?.phone       || '',
+            address:     profile?.address     || '',
+            blood_group: profile?.blood_group || '',
+        });
+        setSaveMsg(null);
+        setIsEditing(true);
+    };
+
+    const cancelEdit = () => { setIsEditing(false); setSaveMsg(null); };
+
+    const handleSave = async () => {
+        setSaving(true);
+        setSaveMsg(null);
+        try {
+            const res = await fetch(`${API}/api/patients/${user.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(form),
+            });
+            if (!res.ok) throw new Error('Failed');
+            const updated = await res.json();
+            setProfile(updated);
+            login({ ...user, first_name: updated.first_name, last_name: updated.last_name });
+            setIsEditing(false);
+            setSaveMsg({ type: 'success', text: 'Profile updated successfully!' });
+            setTimeout(() => setSaveMsg(null), 3000);
+        } catch {
+            setSaveMsg({ type: 'error', text: 'Failed to save. Please try again.' });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const Field = ({ label, icon: Icon, value, editContent }) => (
+        <div>
+            <label className="block text-sm font-semibold text-gray-900 mb-1">{label}</label>
+            {isEditing && editContent ? editContent : (
+                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-gray-700 border border-gray-100">
+                    {Icon && <Icon size={18} className="text-gray-400 flex-shrink-0" />}
+                    <span>{value || '—'}</span>
+                </div>
+            )}
+        </div>
+    );
 
     return (
         <div className="max-w-6xl mx-auto space-y-8 pb-10">
@@ -76,49 +134,91 @@ const PatientProfile = () => {
                     <div className="bg-white rounded-3xl shadow-sm border border-gray-100 p-8">
                         <div className="flex justify-between items-center mb-6 border-b border-gray-100 pb-4">
                             <h3 className="text-xl font-bold text-gray-900">Personal Information</h3>
+                            {!isEditing ? (
+                                <button
+                                    onClick={startEdit}
+                                    className="px-4 py-2 text-sm font-medium text-primary border border-primary/30 rounded-xl hover:bg-primary-light transition-colors"
+                                >
+                                    Edit Profile
+                                </button>
+                            ) : (
+                                <div className="flex gap-2">
+                                    <button onClick={cancelEdit} className="px-4 py-2 text-sm font-medium text-gray-600 border border-gray-200 rounded-xl hover:bg-gray-50 transition-colors flex items-center gap-1">
+                                        <X size={14} /> Cancel
+                                    </button>
+                                    <button
+                                        onClick={handleSave}
+                                        disabled={saving}
+                                        className="px-4 py-2 text-sm font-medium text-white bg-primary rounded-xl hover:bg-primary-hover transition-colors flex items-center gap-1 disabled:opacity-60"
+                                    >
+                                        <Save size={14} /> {saving ? 'Saving...' : 'Save Changes'}
+                                    </button>
+                                </div>
+                            )}
                         </div>
 
+                        {saveMsg && (
+                            <div className={`mb-4 p-3 rounded-xl text-sm font-medium ${saveMsg.type === 'success' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'}`}>
+                                {saveMsg.text}
+                            </div>
+                        )}
+
                         <div className="grid md:grid-cols-2 gap-6">
-                            <div>
-                                <label className="block text-sm font-semibold text-gray-900 mb-1">Full Name</label>
-                                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-gray-700 border border-gray-100">
-                                    <User size={18} className="text-gray-400" />
-                                    {fullName}
-                                </div>
-                            </div>
-                            <div>
-                                <label className="block text-sm font-semibold text-gray-900 mb-1">Date of Birth</label>
-                                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-gray-700 border border-gray-100">
-                                    <User size={18} className="text-gray-400" />
-                                    {profile ? formatDOB(profile.dob) : '—'}
-                                </div>
-                            </div>
+                            <Field
+                                label="First Name"
+                                icon={User}
+                                value={profile?.first_name}
+                                editContent={
+                                    <input className={inputClass} value={form.first_name} onChange={e => setForm(p => ({ ...p, first_name: e.target.value }))} />
+                                }
+                            />
+                            <Field
+                                label="Last Name"
+                                icon={User}
+                                value={profile?.last_name}
+                                editContent={
+                                    <input className={inputClass} value={form.last_name} onChange={e => setForm(p => ({ ...p, last_name: e.target.value }))} />
+                                }
+                            />
+                            <Field
+                                label="Date of Birth"
+                                icon={User}
+                                value={profile ? formatDOB(profile.dob) : null}
+                            />
                             <div className="md:col-span-2">
-                                <label className="block text-sm font-semibold text-gray-900 mb-1">Email Address</label>
-                                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-gray-700 border border-gray-100">
-                                    <Mail size={18} className="text-gray-400" />
-                                    {user?.email}
-                                </div>
+                                <Field
+                                    label="Email Address"
+                                    icon={Mail}
+                                    value={user?.email}
+                                />
                             </div>
-                            <div>
-                                <label className="block text-sm font-semibold text-gray-900 mb-1">Phone Number</label>
-                                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-gray-700 border border-gray-100">
-                                    <Phone size={18} className="text-gray-400" />
-                                    {profile?.phone || '—'}
-                                </div>
-                            </div>
-                            <div>
-                                <label className="block text-sm font-semibold text-gray-900 mb-1">Blood Group</label>
-                                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-red-600 font-bold border border-gray-100">
-                                    {profile?.blood_group || '—'}
-                                </div>
-                            </div>
+                            <Field
+                                label="Phone Number"
+                                icon={Phone}
+                                value={profile?.phone}
+                                editContent={
+                                    <input className={inputClass} type="tel" value={form.phone} onChange={e => setForm(p => ({ ...p, phone: e.target.value }))} />
+                                }
+                            />
+                            <Field
+                                label="Blood Group"
+                                value={profile?.blood_group}
+                                editContent={
+                                    <select className={inputClass} value={form.blood_group} onChange={e => setForm(p => ({ ...p, blood_group: e.target.value }))}>
+                                        <option value="">Select</option>
+                                        {BLOOD_GROUPS.map(bg => <option key={bg} value={bg}>{bg}</option>)}
+                                    </select>
+                                }
+                            />
                             <div className="md:col-span-2">
-                                <label className="block text-sm font-semibold text-gray-900 mb-1">Address</label>
-                                <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl text-gray-700 border border-gray-100">
-                                    <MapPin size={18} className="text-gray-400 flex-shrink-0" />
-                                    {profile?.address || '—'}
-                                </div>
+                                <Field
+                                    label="Address"
+                                    icon={MapPin}
+                                    value={profile?.address}
+                                    editContent={
+                                        <input className={inputClass} value={form.address} onChange={e => setForm(p => ({ ...p, address: e.target.value }))} />
+                                    }
+                                />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

- **P2 — Patient profile editing:** `PatientProfile.jsx` fully rewritten with an edit mode toggle. `Field` component renders static view or live input depending on `isEditing` state. `PATCH /api/patients/:id` backend endpoint added using COALESCE pattern (only overwrites non-null fields). On save, syncs `AuthContext` and shows a 3-second success toast.
- **A1 — Admin edit users:** `AdminUsers.jsx` extended with a Pencil icon button per non-ADMIN row. Clicking it fetches full user detail and opens a reused modal (`showForm='edit'`) pre-filled with current values. Separate form layouts for editing doctors (name, specialty, degree, experience, room) and patients (name, blood group, phone, address). PATCHes to existing `/api/doctors/:id` and `/api/patients/:id` endpoints.

## Test plan

- [ ] Patient login → My Profile → Edit Profile → change name/phone/blood group → Save → values persist
- [ ] Patient login → My Profile → Edit Profile → Cancel → no changes applied
- [ ] Admin login → Manage Users → click Pencil on a doctor → edit specialty → Save → table refreshes
- [ ] Admin login → Manage Users → click Pencil on a patient → edit blood group → Save → table refreshes
- [ ] Admin login → Pencil icon not shown for ADMIN row

🤖 Generated with [Claude Code](https://claude.com/claude-code)