### PR TITLE
fix(X1,X2): bcrypt password hashing + JWT authorization middleware

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+PORT=5001
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=your_db_password
+DB_NAME=hospital_system
+JWT_SECRET=change_this_to_a_long_random_secret

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -64,12 +64,12 @@ CREATE TABLE IF NOT EXISTS live_queue (
     FOREIGN KEY (appointment_id) REFERENCES appointments(id)
 );
 
--- Insert Mock Users (passwords stored as plain text for dev/educational use)
+-- Insert Mock Users (passwords are bcrypt hashes — plain-text values: patient123, doctor123, admin123)
 INSERT IGNORE INTO users (id, email, password_hash, role) VALUES
-(1, 'patient@example.com', 'patient123', 'PATIENT'),
-(2, 'dr.sarah@hospital.com', 'doctor123', 'DOCTOR'),
-(3, 'dr.michael@hospital.com', 'doctor123', 'DOCTOR'),
-(10, 'admin@hospital.com', 'admin123', 'ADMIN');
+(1,  'patient@example.com',        '$2b$10$pr3yTOhaCSWoCCKx6dh5zuHdBjIb5OiArA8HmGrZY9pS23x3rw17W', 'PATIENT'),
+(2,  'dr.sarah@hospital.com',      '$2b$10$jlF3vybJbXMc7y5DESbqXOLOtL2i86bPyWA6AefbPhq1lGRwh/DPG', 'DOCTOR'),
+(3,  'dr.michael@hospital.com',    '$2b$10$jlF3vybJbXMc7y5DESbqXOLOtL2i86bPyWA6AefbPhq1lGRwh/DPG', 'DOCTOR'),
+(10, 'admin@hospital.com',         '$2b$10$6b1GuRKjy.ASXaKM.t/XVOYEJDrTxNSbe8AuM414NtK.YbgbaGfQe', 'ADMIN');
 
 -- Insert Mock Patients
 INSERT IGNORE INTO patients (id, first_name, last_name, dob, phone, blood_group, address) VALUES
@@ -90,9 +90,9 @@ INSERT IGNORE INTO live_queue (appointment_id, queue_number, status, estimated_t
 (1, 18, 'WAITING', 45);
 
 -- -------------------------------------------------------
--- Run the following ALTER if DB already exists (one-time):
+-- Run the following ALTERs if DB already exists (one-time migration):
 -- ALTER TABLE appointments ADD COLUMN IF NOT EXISTS symptoms TEXT AFTER time_slot;
--- UPDATE users SET password_hash = 'patient123' WHERE id = 1;
--- UPDATE users SET password_hash = 'doctor123' WHERE id IN (2, 3);
--- INSERT IGNORE INTO users (id, email, password_hash, role) VALUES (10, 'admin@hospital.com', 'admin123', 'ADMIN');
+-- INSERT IGNORE INTO users (id, email, password_hash, role) VALUES (10, 'admin@hospital.com', '$2b$10$6b1GuRKjy.ASXaKM.t/XVOYEJDrTxNSbe8AuM414NtK.YbgbaGfQe', 'ADMIN');
+-- UPDATE users SET password_hash = '$2b$10$pr3yTOhaCSWoCCKx6dh5zuHdBjIb5OiArA8HmGrZY9pS23x3rw17W' WHERE id = 1;
+-- UPDATE users SET password_hash = '$2b$10$jlF3vybJbXMc7y5DESbqXOLOtL2i86bPyWA6AefbPhq1lGRwh/DPG' WHERE id IN (2, 3);
 -- -------------------------------------------------------

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "jsonwebtoken": "^9.0.3",
         "mysql2": "^3.18.2"
       },
       "devDependencies": {
@@ -72,6 +74,15 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/binary-extensions": {
@@ -136,6 +147,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -316,6 +333,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -718,6 +744,91 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -1060,6 +1171,26 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1070,7 +1201,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,9 +12,11 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "jsonwebtoken": "^9.0.3",
     "mysql2": "^3.18.2"
   },
   "devDependencies": {

--- a/backend/src/middleware/authenticate.js
+++ b/backend/src/middleware/authenticate.js
@@ -1,0 +1,36 @@
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev_secret_change_in_production';
+
+/**
+ * Middleware: verify Bearer JWT token.
+ * On success attaches req.user = { id, email, role }.
+ */
+function authenticate(req, res, next) {
+    const authHeader = req.headers['authorization'];
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ message: 'Authentication required' });
+    }
+    const token = authHeader.slice(7);
+    try {
+        req.user = jwt.verify(token, JWT_SECRET);
+        next();
+    } catch {
+        return res.status(401).json({ message: 'Invalid or expired token' });
+    }
+}
+
+/**
+ * Middleware factory: require a specific role.
+ * Usage: requireRole('ADMIN')
+ */
+function requireRole(role) {
+    return (req, res, next) => {
+        if (!req.user || req.user.role !== role) {
+            return res.status(403).json({ message: 'Insufficient permissions' });
+        }
+        next();
+    };
+}
+
+module.exports = { authenticate, requireRole, JWT_SECRET };

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,6 +1,14 @@
 const express = require('express');
 const router = express.Router();
+const bcrypt = require('bcryptjs');
 const db = require('../config/db');
+const { authenticate, requireRole } = require('../middleware/authenticate');
+
+const BCRYPT_ROUNDS = 10;
+
+// All admin routes require authentication + ADMIN role
+router.use(authenticate);
+router.use(requireRole('ADMIN'));
 
 // GET /api/admin/users — all users with profile info
 router.get('/users', async (req, res) => {
@@ -39,11 +47,12 @@ router.post('/doctors', async (req, res) => {
     const conn = await db.getConnection();
     try {
         const { email, password, first_name, last_name, specialty, degree, experience_years, location_room } = req.body;
+        const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
         await conn.beginTransaction();
 
         const [userResult] = await conn.query(
             'INSERT INTO users (email, password_hash, role) VALUES (?, ?, ?)',
-            [email, password, 'DOCTOR']
+            [email, passwordHash, 'DOCTOR']
         );
         const newId = userResult.insertId;
 
@@ -83,11 +92,12 @@ router.post('/patients', async (req, res) => {
     const conn = await db.getConnection();
     try {
         const { email, password, first_name, last_name, dob, phone, blood_group, address } = req.body;
+        const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
         await conn.beginTransaction();
 
         const [userResult] = await conn.query(
             'INSERT INTO users (email, password_hash, role) VALUES (?, ?, ?)',
-            [email, password, 'PATIENT']
+            [email, passwordHash, 'PATIENT']
         );
         const newId = userResult.insertId;
 

--- a/backend/src/routes/appointments.js
+++ b/backend/src/routes/appointments.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../config/db');
+const { authenticate } = require('../middleware/authenticate');
 
 // POST /api/appointments/book
-router.post('/book', async (req, res) => {
+router.post('/book', authenticate, async (req, res) => {
     try {
         const { patientId, doctorId, date, timeSlot, symptoms } = req.body;
 
@@ -90,7 +91,7 @@ router.get('/queue/:appointmentId', async (req, res) => {
 });
 
 // PATCH /api/appointments/queue/:queueId/status — update a token's status (for doctor/assistant)
-router.patch('/queue/:queueId/status', async (req, res) => {
+router.patch('/queue/:queueId/status', authenticate, async (req, res) => {
     try {
         const { status } = req.body;
         const validStatuses = ['WAITING', 'IN_PROGRESS', 'COMPLETED', 'MISSED'];

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,6 +1,11 @@
 const express = require('express');
 const router = express.Router();
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
 const db = require('../config/db');
+const { JWT_SECRET } = require('../middleware/authenticate');
+
+const BCRYPT_ROUNDS = 10;
 
 // POST /api/auth/login
 router.post('/login', async (req, res) => {
@@ -10,16 +15,18 @@ router.post('/login', async (req, res) => {
             return res.status(400).json({ message: 'Email and password are required' });
         }
 
-        const [users] = await db.query(
-            'SELECT * FROM users WHERE email = ? AND password_hash = ?',
-            [email, password]
-        );
-
+        // Fetch user by email only; compare password separately (never compare in SQL)
+        const [users] = await db.query('SELECT * FROM users WHERE email = ?', [email]);
         if (users.length === 0) {
             return res.status(401).json({ message: 'Invalid email or password' });
         }
 
         const user = users[0];
+        const passwordMatch = await bcrypt.compare(password, user.password_hash);
+        if (!passwordMatch) {
+            return res.status(401).json({ message: 'Invalid email or password' });
+        }
+
         let firstName = 'Admin';
         let lastName = '';
 
@@ -31,7 +38,20 @@ router.post('/login', async (req, res) => {
             if (rows.length > 0) { firstName = rows[0].first_name; lastName = rows[0].last_name; }
         }
 
-        res.json({ id: user.id, email: user.email, role: user.role, first_name: firstName, last_name: lastName });
+        const token = jwt.sign(
+            { id: user.id, email: user.email, role: user.role },
+            JWT_SECRET,
+            { expiresIn: '8h' }
+        );
+
+        res.json({
+            id: user.id,
+            email: user.email,
+            role: user.role,
+            first_name: firstName,
+            last_name: lastName,
+            token,
+        });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Server error' });
@@ -53,11 +73,13 @@ router.post('/register', async (req, res) => {
             return res.status(409).json({ message: 'An account with this email already exists' });
         }
 
+        const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+
         await conn.beginTransaction();
 
         const [userResult] = await conn.query(
             'INSERT INTO users (email, password_hash, role) VALUES (?, ?, ?)',
-            [email, password, 'PATIENT']
+            [email, passwordHash, 'PATIENT']
         );
         const newId = userResult.insertId;
 

--- a/backend/src/routes/doctors.js
+++ b/backend/src/routes/doctors.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const db = require('../config/db');
+const { authenticate } = require('../middleware/authenticate');
 
 // GET /api/doctors — all doctors
 router.get('/', async (req, res) => {
@@ -26,7 +27,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // PATCH /api/doctors/:id — update doctor profile (photo, bio, specialty, etc.)
-router.patch('/:id', async (req, res) => {
+router.patch('/:id', authenticate, async (req, res) => {
     try {
         const { first_name, last_name, specialty, degree, experience_years, about, location_room, image_url, max_patients_per_slot } = req.body;
         await db.query(
@@ -72,7 +73,7 @@ router.get('/:id/slot-counts', async (req, res) => {
 });
 
 // PATCH /api/doctors/:id/availability — update weekly schedule
-router.patch('/:id/availability', async (req, res) => {
+router.patch('/:id/availability', authenticate, async (req, res) => {
     try {
         const { availability } = req.body;
         if (!availability || typeof availability !== 'object') {

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,10 @@
+export const API = import.meta.env.VITE_API_URL ?? 'http://localhost:5001';
+
+/** Returns headers for an authenticated request.
+ *  Pass body=true when sending JSON to also include Content-Type. */
+export function authedHeaders(body = false) {
+    const token = localStorage.getItem('hs_token') ?? '';
+    const headers = { Authorization: `Bearer ${token}` };
+    if (body) headers['Content-Type'] = 'application/json';
+    return headers;
+}

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -13,13 +13,19 @@ export function AuthProvider({ children }) {
     });
 
     function login(userData) {
-        setUser(userData);
-        localStorage.setItem('hs_user', JSON.stringify(userData));
+        // userData may include a `token` field on initial login; store it separately
+        const { token, ...rest } = userData;
+        setUser(rest);
+        localStorage.setItem('hs_user', JSON.stringify(rest));
+        if (token) {
+            localStorage.setItem('hs_token', token);
+        }
     }
 
     function logout() {
         setUser(null);
         localStorage.removeItem('hs_user');
+        localStorage.removeItem('hs_token');
     }
 
     return (

--- a/frontend/src/pages/AdminAppointments.jsx
+++ b/frontend/src/pages/AdminAppointments.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { AlertCircle, Calendar, Clock, Filter } from 'lucide-react';
+import { API, authedHeaders } from '../config/api';
 
 const STATUS_STYLES = {
     CONFIRMED: 'bg-green-100 text-green-700',
@@ -15,7 +16,7 @@ const AdminAppointments = () => {
     const [filterStatus, setFilterStatus] = useState('ALL');
 
     useEffect(() => {
-        fetch('http://localhost:5001/api/admin/appointments')
+        fetch(`${API}/api/admin/appointments`, { headers: authedHeaders() })
             .then(res => res.json())
             .then(data => setAppointments(data))
             .catch(err => console.error(err))

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Users, Calendar, Stethoscope, Activity } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { API, authedHeaders } from '../config/api';
 
 const StatCard = ({ title, value, icon: Icon, color, onClick }) => (
     <button
@@ -23,7 +24,7 @@ const AdminDashboard = () => {
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        fetch('http://localhost:5001/api/admin/stats')
+        fetch(`${API}/api/admin/stats`, { headers: authedHeaders() })
             .then(res => res.json())
             .then(data => setStats(data))
             .catch(err => console.error(err))

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Trash2, Stethoscope, Users, X } from 'lucide-react';
+import { API, authedHeaders } from '../config/api';
 
 const AdminUsers = () => {
     const [users, setUsers] = useState([]);
@@ -11,7 +12,7 @@ const AdminUsers = () => {
     const [filterRole, setFilterRole] = useState('ALL');
 
     const fetchUsers = () => {
-        fetch('http://localhost:5001/api/admin/users')
+        fetch(`${API}/api/admin/users`, { headers: authedHeaders() })
             .then(res => res.json())
             .then(data => setUsers(data))
             .catch(err => console.error(err))
@@ -24,7 +25,7 @@ const AdminUsers = () => {
         if (!confirm(`Are you sure you want to remove this ${role.toLowerCase()}? This will also delete all their appointments.`)) return;
         const endpoint = role === 'DOCTOR' ? `/api/admin/doctors/${id}` : `/api/admin/patients/${id}`;
         try {
-            await fetch(`http://localhost:5001${endpoint}`, { method: 'DELETE' });
+            await fetch(`${API}${endpoint}`, { method: 'DELETE', headers: authedHeaders() });
             setUsers(prev => prev.filter(u => u.id !== id));
         } catch (err) {
             console.error(err);
@@ -38,9 +39,9 @@ const AdminUsers = () => {
         setError('');
         setSubmitting(true);
         try {
-            const res = await fetch('http://localhost:5001/api/admin/doctors', {
+            const res = await fetch(`${API}/api/admin/doctors`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: authedHeaders(true),
                 body: JSON.stringify(formData)
             });
             const data = await res.json();
@@ -60,9 +61,9 @@ const AdminUsers = () => {
         setError('');
         setSubmitting(true);
         try {
-            const res = await fetch('http://localhost:5001/api/admin/patients', {
+            const res = await fetch(`${API}/api/admin/patients`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: authedHeaders(true),
                 body: JSON.stringify(formData)
             });
             const data = await res.json();

--- a/frontend/src/pages/BookAppointment.jsx
+++ b/frontend/src/pages/BookAppointment.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Calendar as CalendarIcon, Clock, ChevronLeft, ChevronRight, CheckCircle2, Users } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { API, authedHeaders } from '../config/api';
 
 const DAY_NAMES = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
 
@@ -64,7 +65,7 @@ const BookAppointment = () => {
     const [currentMonth, setCurrentMonth] = useState(new Date());
 
     useEffect(() => {
-        fetch('http://localhost:5001/api/doctors')
+        fetch(`${API}/api/doctors`)
             .then(res => res.json())
             .then(data => {
                 setDoctors(data);
@@ -80,7 +81,7 @@ const BookAppointment = () => {
     useEffect(() => {
         if (!selectedDoctor || !selectedDate) return;
         setSelectedSlot(null);
-        fetch(`http://localhost:5001/api/doctors/${selectedDoctor}/slot-counts?date=${selectedDate}`)
+        fetch(`${API}/api/doctors/${selectedDoctor}/slot-counts?date=${selectedDate}`)
             .then(res => res.json())
             .then(data => setSlotCounts(data))
             .catch(() => setSlotCounts({}));
@@ -294,9 +295,9 @@ const BookAppointment = () => {
                         onClick={async () => {
                             setIsSubmitting(true);
                             try {
-                                await fetch('http://localhost:5001/api/appointments/book', {
+                                await fetch(`${API}/api/appointments/book`, {
                                     method: 'POST',
-                                    headers: { 'Content-Type': 'application/json' },
+                                    headers: authedHeaders(true),
                                     body: JSON.stringify({
                                         patientId: user.id,
                                         doctorId: selectedDoctor,

--- a/frontend/src/pages/DoctorDashboard.jsx
+++ b/frontend/src/pages/DoctorDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { User, Calendar, Clock, AlertCircle, CheckCircle2, Activity, Users } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { API, authedHeaders } from '../config/api';
 
 const STATUS_COLORS = {
     WAITING: 'bg-yellow-100 text-yellow-700 border-yellow-200',
@@ -35,8 +36,8 @@ const DoctorDashboard = () => {
         if (!user?.id) return;
         try {
             const [patientsRes, queueRes] = await Promise.all([
-                fetch(`http://localhost:5001/api/doctors/${user.id}/patients`),
-                fetch(`http://localhost:5001/api/doctors/${user.id}/queue`)
+                fetch(`${API}/api/doctors/${user.id}/patients`),
+                fetch(`${API}/api/doctors/${user.id}/queue`)
             ]);
             const patientsData = await patientsRes.json();
             const queueData = await queueRes.json();
@@ -54,9 +55,9 @@ const DoctorDashboard = () => {
     const updateQueueStatus = async (queueId, newStatus) => {
         setUpdatingId(queueId);
         try {
-            await fetch(`http://localhost:5001/api/appointments/queue/${queueId}/status`, {
+            await fetch(`${API}/api/appointments/queue/${queueId}/status`, {
                 method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
+                headers: authedHeaders(true),
                 body: JSON.stringify({ status: newStatus })
             });
             setQueue(prev => prev.map(q => q.queue_id === queueId ? { ...q, queue_status: newStatus } : q));
@@ -70,9 +71,9 @@ const DoctorDashboard = () => {
     const markMissed = async (queueId) => {
         setUpdatingId(queueId);
         try {
-            await fetch(`http://localhost:5001/api/appointments/queue/${queueId}/status`, {
+            await fetch(`${API}/api/appointments/queue/${queueId}/status`, {
                 method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
+                headers: authedHeaders(true),
                 body: JSON.stringify({ status: 'MISSED' })
             });
             setQueue(prev => prev.map(q => q.queue_id === queueId ? { ...q, queue_status: 'MISSED' } : q));

--- a/frontend/src/pages/DoctorProfileEdit.jsx
+++ b/frontend/src/pages/DoctorProfileEdit.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Camera, Save, Clock, CheckCircle2, AlertCircle, User, MapPin, Award, BookOpen } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { API, authedHeaders } from '../config/api';
 
 const DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
 const DAY_LABELS = { monday: 'Mon', tuesday: 'Tue', wednesday: 'Wed', thursday: 'Thu', friday: 'Fri', saturday: 'Sat', sunday: 'Sun' };
@@ -36,7 +37,7 @@ const DoctorProfileEdit = () => {
     // Load current doctor data
     useEffect(() => {
         if (!user?.id) return;
-        fetch(`http://localhost:5001/api/doctors/${user.id}`)
+        fetch(`${API}/api/doctors/${user.id}`)
             .then(res => res.json())
             .then(data => {
                 setProfile({
@@ -88,9 +89,9 @@ const DoctorProfileEdit = () => {
         setSavingProfile(true);
         setProfileMsg(null);
         try {
-            const res = await fetch(`http://localhost:5001/api/doctors/${user.id}`, {
+            const res = await fetch(`${API}/api/doctors/${user.id}`, {
                 method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
+                headers: authedHeaders(true),
                 body: JSON.stringify(profile),
             });
             if (!res.ok) throw new Error('Failed');
@@ -121,9 +122,9 @@ const DoctorProfileEdit = () => {
         setSavingAvail(true);
         setAvailMsg(null);
         try {
-            const res = await fetch(`http://localhost:5001/api/doctors/${user.id}/availability`, {
+            const res = await fetch(`${API}/api/doctors/${user.id}/availability`, {
                 method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
+                headers: authedHeaders(true),
                 body: JSON.stringify({ availability }),
             });
             if (!res.ok) throw new Error('Failed');


### PR DESCRIPTION
## Summary

### X1 — Plain text passwords → bcrypt hashing
- Installed `bcryptjs` and `jsonwebtoken`
- `auth.js` login: fetch user by email only, then `bcrypt.compare(password, hash)` — passwords are never compared in SQL
- `auth.js` register + `admin.js` create doctor/patient: `bcrypt.hash(password, 10)` before storing
- `schema.sql`: seed data updated to use pre-computed bcrypt hashes (plain-text equivalents documented in comment)
- `backend/.env.example`: added `JWT_SECRET` entry

### X2 — No backend authorization → JWT middleware
- New `backend/src/middleware/authenticate.js`: `authenticate` (verify Bearer JWT) + `requireRole(role)` factory
- `auth.js` login: signs 8h JWT and returns `token` field in response
- `admin.js`: `router.use(authenticate, requireRole('ADMIN'))` — all admin routes protected
- `appointments.js`: `authenticate` middleware on `POST /book` and `PATCH /queue/:id/status`
- `doctors.js`: `authenticate` middleware on both `PATCH /:id` routes
- `AuthContext.jsx`: stores/clears `hs_token` in localStorage on login/logout; strips `token` from user state
- `frontend/src/config/api.js`: `API` constant + `authedHeaders(body?)` helper function
- All admin page fetch calls updated to include `Authorization: Bearer` header
- `BookAppointment`, `DoctorDashboard`, `DoctorProfileEdit` write calls updated with `authedHeaders`

## Test plan

- [ ] Login as patient → JWT stored in localStorage as `hs_token`
- [ ] Book appointment → POST succeeds with token
- [ ] Book appointment without token (direct curl) → 401 Unauthorized
- [ ] Access admin dashboard without token → 401
- [ ] Login as admin → admin pages load correctly with stats/users/appointments
- [ ] Admin add doctor → bcrypt hash stored (not plain text) in DB
- [ ] Doctor update queue status → PATCH succeeds with token
- [ ] Logout → `hs_token` cleared from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)