### PR TITLE
fix(P4,P7): appointment history tab + real patient stats

### DIFF
--- a/backend/src/routes/patients.js
+++ b/backend/src/routes/patients.js
@@ -16,17 +16,34 @@ router.get('/:id', async (req, res) => {
     }
 });
 
-// Get a patient's appointments
+// Get a patient's appointments — supports ?type=upcoming|past (default: upcoming)
 router.get('/:id/appointments', async (req, res) => {
     try {
+        const type = req.query.type || 'upcoming';
+
+        let whereClause;
+        let orderClause;
+        if (type === 'past') {
+            // Completed/cancelled OR in the past
+            whereClause = `a.patient_id = ? AND (a.appointment_date < CURDATE() OR a.status IN ('COMPLETED', 'CANCELLED'))`;
+            orderClause = 'ORDER BY a.appointment_date DESC';
+        } else if (type === 'all') {
+            whereClause = `a.patient_id = ?`;
+            orderClause = 'ORDER BY a.appointment_date DESC';
+        } else {
+            // upcoming: today or future, not cancelled/completed
+            whereClause = `a.patient_id = ? AND a.appointment_date >= CURDATE() AND a.status IN ('CONFIRMED', 'PENDING')`;
+            orderClause = 'ORDER BY a.appointment_date ASC';
+        }
+
         const query = `
             SELECT a.id, DATE_FORMAT(a.appointment_date, '%Y-%m-%d') AS appointment_date,
                    a.time_slot, a.symptoms, a.status,
                    d.first_name as doc_first, d.last_name as doc_last, d.specialty, d.location_room
             FROM appointments a
             JOIN doctors d ON a.doctor_id = d.id
-            WHERE a.patient_id = ?
-            ORDER BY a.appointment_date ASC
+            WHERE ${whereClause}
+            ${orderClause}
         `;
         const [rows] = await db.query(query, [req.params.id]);
         res.json(rows);

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,10 @@
+export const API = import.meta.env.VITE_API_URL ?? 'http://localhost:5001';
+
+/** Returns headers for an authenticated request.
+ *  Pass body=true when sending JSON to also include Content-Type. */
+export function authedHeaders(body = false) {
+    const token = localStorage.getItem('hs_token') ?? '';
+    const headers = { Authorization: `Bearer ${token}` };
+    if (body) headers['Content-Type'] = 'application/json';
+    return headers;
+}

--- a/frontend/src/pages/PatientDashboard.jsx
+++ b/frontend/src/pages/PatientDashboard.jsx
@@ -1,21 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Calendar as CalendarIcon, Clock, MapPin, Activity, FileText, ChevronRight } from 'lucide-react';
+import { Calendar as CalendarIcon, Clock, MapPin, CheckCircle2, User, ChevronRight } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { API } from '../config/api';
 
-const StatCard = ({ title, value, unit, icon: Icon, trend }) => (
+const STATUS_STYLES = {
+    CONFIRMED: 'bg-green-100 text-green-700',
+    PENDING:   'bg-orange-100 text-orange-700',
+    COMPLETED: 'bg-blue-100 text-blue-700',
+    CANCELLED: 'bg-red-100 text-red-700',
+};
+
+const StatCard = ({ title, value, icon: Icon, sub }) => (
     <div className="bg-white p-6 rounded-2xl shadow-sm border border-gray-100 flex items-start justify-between group hover:shadow-md transition-shadow">
         <div>
             <p className="text-sm font-medium text-gray-500 mb-1">{title}</p>
-            <div className="flex items-baseline gap-1">
-                <h3 className="text-3xl font-bold text-gray-800">{value}</h3>
-                {unit && <span className="text-sm text-gray-500">{unit}</span>}
-            </div>
-            {trend && (
-                <p className={`text-xs mt-2 ${trend.isPositive ? 'text-green-600' : 'text-orange-500'}`}>
-                    {trend.value} from last month
-                </p>
-            )}
+            <h3 className="text-3xl font-bold text-gray-800">{value}</h3>
+            {sub && <p className="text-xs text-gray-400 mt-1.5">{sub}</p>}
         </div>
         <div className="p-3 bg-primary-light/50 text-primary rounded-xl group-hover:scale-110 transition-transform">
             <Icon size={24} />
@@ -23,52 +24,66 @@ const StatCard = ({ title, value, unit, icon: Icon, trend }) => (
     </div>
 );
 
-const AppointmentCard = ({ date, time, doctor, specialty, location, status }) => (
-    <div className="bg-white p-5 rounded-2xl border border-gray-100 shadow-sm hover:border-primary/30 transition-colors cursor-pointer">
-        <div className="flex justify-between items-start mb-4">
-            <div className="flex items-center gap-4">
-                <div className="w-14 h-14 bg-gray-100 rounded-full overflow-hidden flex-shrink-0">
-                    <img src={`https://ui-avatars.com/api/?name=${doctor.replace(' ', '+')}&background=random`} alt={doctor} className="w-full h-full object-cover" />
+const AppointmentCard = ({ apt }) => {
+    const doctor = `Dr. ${apt.doc_first} ${apt.doc_last}`;
+    const statusLabel = apt.status.charAt(0).toUpperCase() + apt.status.slice(1).toLowerCase();
+    const dateStr = new Date(apt.appointment_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+    return (
+        <div className="bg-white p-5 rounded-2xl border border-gray-100 shadow-sm hover:border-primary/30 transition-colors">
+            <div className="flex justify-between items-start mb-4">
+                <div className="flex items-center gap-3">
+                    <div className="w-12 h-12 bg-gray-100 rounded-full overflow-hidden flex-shrink-0">
+                        <img src={`https://ui-avatars.com/api/?name=${encodeURIComponent(doctor)}&background=random`} alt={doctor} className="w-full h-full object-cover" />
+                    </div>
+                    <div>
+                        <h4 className="font-semibold text-gray-900 text-sm">{doctor}</h4>
+                        <p className="text-xs text-gray-500">{apt.specialty}</p>
+                    </div>
                 </div>
-                <div>
-                    <h4 className="font-semibold text-gray-900">{doctor}</h4>
-                    <p className="text-sm text-gray-500">{specialty}</p>
+                <span className={`px-2.5 py-1 text-xs font-semibold rounded-full ${STATUS_STYLES[apt.status] || 'bg-gray-100 text-gray-600'}`}>
+                    {statusLabel}
+                </span>
+            </div>
+            <div className="grid grid-cols-2 gap-y-2 text-sm pt-4 border-t border-gray-50">
+                <div className="flex items-center gap-2 text-gray-600">
+                    <CalendarIcon size={14} className="text-primary flex-shrink-0" />
+                    <span className="text-xs">{dateStr}</span>
                 </div>
-            </div>
-            <span className={`px-3 py-1 text-xs font-medium rounded-full ${status === 'Confirmed' ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
-                {status}
-            </span>
-        </div>
-        <div className="grid grid-cols-2 gap-y-3 gap-x-4 text-sm mt-4 pt-4 border-t border-gray-50">
-            <div className="flex items-center gap-2 text-gray-600">
-                <CalendarIcon size={16} className="text-primary" />
-                <span>{date}</span>
-            </div>
-            <div className="flex items-center gap-2 text-gray-600">
-                <Clock size={16} className="text-primary" />
-                <span>{time}</span>
-            </div>
-            <div className="flex items-center gap-2 text-gray-600 col-span-2">
-                <MapPin size={16} className="text-primary" />
-                <span>{location}</span>
+                <div className="flex items-center gap-2 text-gray-600">
+                    <Clock size={14} className="text-primary flex-shrink-0" />
+                    <span className="text-xs">{apt.time_slot}</span>
+                </div>
+                {apt.location_room && (
+                    <div className="flex items-center gap-2 text-gray-600 col-span-2">
+                        <MapPin size={14} className="text-primary flex-shrink-0" />
+                        <span className="text-xs truncate">{apt.location_room}</span>
+                    </div>
+                )}
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 const PatientDashboard = () => {
     const { user } = useAuth();
     const navigate = useNavigate();
-    const [appointments, setAppointments] = useState([]);
+    const [upcoming, setUpcoming] = useState([]);
+    const [past, setPast] = useState([]);
+    const [activeTab, setActiveTab] = useState('upcoming');
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         if (!user?.id) return;
         const fetchData = async () => {
             try {
-                const res = await fetch(`http://localhost:5001/api/patients/${user.id}/appointments`);
-                const data = await res.json();
-                setAppointments(data);
+                const [upRes, pastRes] = await Promise.all([
+                    fetch(`${API}/api/patients/${user.id}/appointments?type=upcoming`),
+                    fetch(`${API}/api/patients/${user.id}/appointments?type=past`),
+                ]);
+                const [upData, pastData] = await Promise.all([upRes.json(), pastRes.json()]);
+                setUpcoming(Array.isArray(upData) ? upData : []);
+                setPast(Array.isArray(pastData) ? pastData : []);
             } catch (err) {
                 console.error('Dashboard error:', err);
             } finally {
@@ -78,16 +93,27 @@ const PatientDashboard = () => {
         fetchData();
     }, [user?.id]);
 
+    // Real derived stats
+    const completedCount = past.filter(a => a.status === 'COMPLETED').length;
+    const uniqueDoctors = new Set([...upcoming, ...past].map(a => `${a.doc_first} ${a.doc_last}`)).size;
+    const nextApt = upcoming[0];
+    const nextAptLabel = nextApt
+        ? new Date(nextApt.appointment_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+        : '—';
+
+    const displayed = activeTab === 'upcoming' ? upcoming : past;
+
     if (isLoading) {
         return <div className="p-10 text-center text-gray-500 font-medium animate-pulse">Loading dashboard...</div>;
     }
 
     return (
         <div className="space-y-8 animate-in fade-in duration-500 pb-10">
+            {/* Header */}
             <div className="flex justify-between items-end">
                 <div>
                     <h1 className="text-2xl font-bold text-gray-900">Welcome back, {user?.first_name}!</h1>
-                    <p className="text-gray-500 mt-1">Here is your health summary for today.</p>
+                    <p className="text-gray-500 mt-1">Here is your appointment summary.</p>
                 </div>
                 <button
                     onClick={() => navigate('/book')}
@@ -97,58 +123,93 @@ const PatientDashboard = () => {
                 </button>
             </div>
 
+            {/* Real stat cards */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                <StatCard title="Blood Pressure" value="120/80" unit="mmHg" icon={Activity} trend={{ value: '-2%', isPositive: true }} />
-                <StatCard title="Heart Rate" value="72" unit="bpm" icon={Activity} trend={{ value: 'Stable', isPositive: true }} />
-                <StatCard title="Weight" value="75" unit="kg" icon={Activity} trend={{ value: '+1kg', isPositive: false }} />
-                <StatCard title="Lab Reports" value="3" icon={FileText} />
+                <StatCard title="Upcoming" value={upcoming.length} icon={CalendarIcon} sub="confirmed & scheduled" />
+                <StatCard title="Completed Visits" value={completedCount} icon={CheckCircle2} sub="all time" />
+                <StatCard title="Doctors Seen" value={uniqueDoctors} icon={User} sub="unique doctors" />
+                <StatCard title="Next Visit" value={nextAptLabel} icon={Clock} sub={nextApt ? nextApt.time_slot : 'no upcoming'} />
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                <div className="lg:col-span-2 space-y-6">
-                    <div className="flex justify-between items-center">
-                        <h2 className="text-lg font-bold text-gray-900">Upcoming Appointments</h2>
-                        <button className="text-primary text-sm font-medium hover:underline flex items-center">
-                            View all <ChevronRight size={16} />
+                {/* Main appointments panel */}
+                <div className="lg:col-span-2 space-y-4">
+                    {/* Tabs */}
+                    <div className="flex gap-2 border-b border-gray-200">
+                        <button
+                            onClick={() => setActiveTab('upcoming')}
+                            className={`pb-3 px-1 text-sm font-semibold border-b-2 transition-colors ${activeTab === 'upcoming' ? 'border-primary text-primary' : 'border-transparent text-gray-500 hover:text-gray-700'}`}
+                        >
+                            Upcoming ({upcoming.length})
+                        </button>
+                        <button
+                            onClick={() => setActiveTab('past')}
+                            className={`pb-3 px-1 text-sm font-semibold border-b-2 transition-colors ${activeTab === 'past' ? 'border-primary text-primary' : 'border-transparent text-gray-500 hover:text-gray-700'}`}
+                        >
+                            Past Visits ({past.length})
                         </button>
                     </div>
-                    <div className="grid sm:grid-cols-2 gap-6">
-                        {appointments.length > 0 ? appointments.map((apt) => (
-                            <AppointmentCard
-                                key={apt.id}
-                                doctor={`Dr. ${apt.doc_first} ${apt.doc_last}`}
-                                specialty={apt.specialty}
-                                date={new Date(apt.appointment_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
-                                time={apt.time_slot}
-                                location={apt.location_room}
-                                status={apt.status.charAt(0).toUpperCase() + apt.status.slice(1).toLowerCase()}
-                            />
-                        )) : (
-                            <p className="text-gray-500 font-medium col-span-2">No upcoming appointments.</p>
-                        )}
-                    </div>
+
+                    {/* Appointment cards */}
+                    {displayed.length > 0 ? (
+                        <div className="grid sm:grid-cols-2 gap-4">
+                            {displayed.map((apt) => (
+                                <AppointmentCard key={apt.id} apt={apt} />
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="py-12 text-center">
+                            <div className="inline-flex items-center justify-center w-16 h-16 bg-gray-100 rounded-full mb-4">
+                                {activeTab === 'upcoming'
+                                    ? <CalendarIcon size={28} className="text-gray-400" />
+                                    : <CheckCircle2 size={28} className="text-gray-400" />
+                                }
+                            </div>
+                            <p className="text-gray-500 font-medium">
+                                {activeTab === 'upcoming' ? 'No upcoming appointments.' : 'No past visits yet.'}
+                            </p>
+                            {activeTab === 'upcoming' && (
+                                <button onClick={() => navigate('/book')} className="mt-4 text-primary text-sm font-medium hover:underline">
+                                    Book your first appointment →
+                                </button>
+                            )}
+                        </div>
+                    )}
                 </div>
 
-                <div className="space-y-6">
-                    <h2 className="text-lg font-bold text-gray-900">Recent Medical History</h2>
-                    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 space-y-6">
-                        <div className="relative pl-6 border-l-2 border-primary/20 space-y-8">
-                            <div className="relative">
-                                <span className="absolute -left-[31px] bg-white border-2 border-primary w-4 h-4 rounded-full"></span>
-                                <p className="text-xs text-gray-500 font-medium tracking-wide uppercase">Sep 15, 2026</p>
-                                <h4 className="text-base font-medium text-gray-900 mt-1">Annual Checkup</h4>
-                                <p className="text-sm text-gray-600 mt-1">Dr. Michael Chen</p>
+                {/* Medical history sidebar — real past appointments */}
+                <div className="space-y-4">
+                    <h2 className="text-lg font-bold text-gray-900">Recent History</h2>
+                    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+                        {past.length === 0 ? (
+                            <p className="text-sm text-gray-400 italic text-center py-4">No visit history yet.</p>
+                        ) : (
+                            <div className="relative pl-6 border-l-2 border-primary/20 space-y-6">
+                                {past.slice(0, 5).map((apt, idx) => (
+                                    <div key={apt.id} className="relative">
+                                        <span className={`absolute -left-[31px] w-4 h-4 rounded-full border-2 bg-white ${idx === 0 ? 'border-primary' : 'border-gray-300'}`}></span>
+                                        <p className="text-xs text-gray-500 font-medium tracking-wide uppercase">
+                                            {new Date(apt.appointment_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+                                        </p>
+                                        <h4 className="text-sm font-semibold text-gray-900 mt-0.5">
+                                            Dr. {apt.doc_first} {apt.doc_last}
+                                        </h4>
+                                        <p className="text-xs text-gray-500">{apt.specialty}</p>
+                                        <span className={`inline-block mt-1 px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_STYLES[apt.status] || 'bg-gray-100 text-gray-600'}`}>
+                                            {apt.status.toLowerCase()}
+                                        </span>
+                                    </div>
+                                ))}
                             </div>
-                            <div className="relative">
-                                <span className="absolute -left-[31px] bg-white border-2 border-gray-300 w-4 h-4 rounded-full"></span>
-                                <p className="text-xs text-gray-500 font-medium tracking-wide uppercase">Jul 02, 2026</p>
-                                <h4 className="text-base font-medium text-gray-900 mt-1">Blood Test</h4>
-                                <p className="text-sm text-gray-600 mt-1">Normal hemoglobin levels.</p>
-                            </div>
-                        </div>
-                        <button className="w-full py-2 border border-gray-200 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors">
-                            Download Full Report
-                        </button>
+                        )}
+                        {past.length > 0 && (
+                            <button
+                                onClick={() => setActiveTab('past')}
+                                className="w-full mt-6 py-2 border border-gray-200 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors flex items-center justify-center gap-1"
+                            >
+                                View all history <ChevronRight size={14} />
+                            </button>
+                        )}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

### P4 — Appointment history (past visits)
- `GET /api/patients/:id/appointments` now supports `?type=upcoming|past|all`
  - `upcoming` (default): `appointment_date >= today AND status IN ('CONFIRMED','PENDING')`
  - `past`: `appointment_date < today OR status IN ('COMPLETED','CANCELLED')`
- Patient dashboard has **Upcoming** / **Past Visits** tabs with live item counts

### P7 — Remove hardcoded health stat cards
- Removed fake Blood Pressure / Heart Rate / Weight / Lab Reports cards
- Replaced with 4 real stat cards computed from the API response:
  - **Upcoming** — confirmed & scheduled count
  - **Completed Visits** — all-time completed appointments
  - **Doctors Seen** — unique doctor count across all appointments
  - **Next Visit** — date + time of next appointment (or `—`)
- **Recent History** sidebar replaced with last 5 real past appointments showing date, doctor, specialty, and status badge
- "View all history" button in sidebar switches the main panel to the Past tab

## Test plan

- [ ] Patient login → dashboard shows real counts (not fake 120/80 etc.)
- [ ] Patient with no appointments → stat cards show 0 / `—`
- [ ] Click **Past Visits** tab → shows completed/cancelled/old appointments
- [ ] Recent History sidebar shows real past entries
- [ ] `GET /api/patients/:id/appointments?type=past` returns only past/done appointments

🤖 Generated with [Claude Code](https://claude.com/claude-code)