### PR TITLE
feat(A3+A4): Admin live queue overview and extended stats dashboard

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -141,15 +141,100 @@ router.get('/appointments', async (req, res) => {
     }
 });
 
-// GET /api/admin/stats — overview stats
+// GET /api/admin/stats — extended overview stats
 router.get('/stats', async (req, res) => {
     try {
         const [[{ total_doctors }]] = await db.query('SELECT COUNT(*) AS total_doctors FROM doctors');
         const [[{ total_patients }]] = await db.query('SELECT COUNT(*) AS total_patients FROM patients');
-        const [[{ today_appointments }]] = await db.query(
-            "SELECT COUNT(*) AS today_appointments FROM appointments WHERE appointment_date = CURDATE()"
+        const [[{ total_appointments }]] = await db.query('SELECT COUNT(*) AS total_appointments FROM appointments');
+        const [[{ today_total }]] = await db.query(
+            "SELECT COUNT(*) AS today_total FROM appointments WHERE appointment_date = CURDATE()"
         );
-        res.json({ total_doctors, total_patients, today_appointments });
+        const [[{ today_confirmed }]] = await db.query(
+            "SELECT COUNT(*) AS today_confirmed FROM appointments WHERE appointment_date = CURDATE() AND status = 'CONFIRMED'"
+        );
+        const [[{ today_completed }]] = await db.query(
+            "SELECT COUNT(*) AS today_completed FROM appointments WHERE appointment_date = CURDATE() AND status = 'COMPLETED'"
+        );
+        const [[{ today_pending }]] = await db.query(
+            "SELECT COUNT(*) AS today_pending FROM appointments WHERE appointment_date = CURDATE() AND status = 'PENDING'"
+        );
+        const [[{ today_cancelled }]] = await db.query(
+            "SELECT COUNT(*) AS today_cancelled FROM appointments WHERE appointment_date = CURDATE() AND status = 'CANCELLED'"
+        );
+
+        // Top 5 doctors by appointment count today
+        const [top_doctors_today] = await db.query(`
+            SELECT d.id, d.first_name, d.last_name, d.specialty,
+                   COUNT(a.id) AS count
+            FROM doctors d
+            LEFT JOIN appointments a ON d.id = a.doctor_id AND a.appointment_date = CURDATE()
+            GROUP BY d.id
+            ORDER BY count DESC
+            LIMIT 5
+        `);
+
+        res.json({
+            total_doctors, total_patients, total_appointments,
+            today_total, today_confirmed, today_completed, today_pending, today_cancelled,
+            // backward compat alias
+            today_appointments: today_total,
+            top_doctors_today,
+        });
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// GET /api/admin/queue-overview — today's live queue grouped by doctor
+router.get('/queue-overview', async (req, res) => {
+    try {
+        // All doctors who have appointments today
+        const [doctors] = await db.query(`
+            SELECT DISTINCT d.id, d.first_name, d.last_name, d.specialty
+            FROM doctors d
+            JOIN appointments a ON a.doctor_id = d.id
+            WHERE a.appointment_date = CURDATE()
+            ORDER BY d.first_name
+        `);
+
+        const result = [];
+
+        for (const doc of doctors) {
+            const [queue] = await db.query(`
+                SELECT lq.id AS queue_id, lq.queue_number, lq.status AS queue_status,
+                       CONCAT(p.first_name, ' ', p.last_name) AS patient_name,
+                       a.time_slot
+                FROM live_queue lq
+                JOIN appointments a ON lq.appointment_id = a.id
+                JOIN patients p ON a.patient_id = p.id
+                WHERE a.doctor_id = ? AND a.appointment_date = CURDATE()
+                ORDER BY lq.queue_number ASC
+            `, [doc.id]);
+
+            const counts = { WAITING: 0, IN_PROGRESS: 0, COMPLETED: 0, MISSED: 0 };
+            queue.forEach(q => { counts[q.queue_status] = (counts[q.queue_status] || 0) + 1; });
+
+            const [[{ total_today }]] = await db.query(
+                'SELECT COUNT(*) AS total_today FROM appointments WHERE doctor_id = ? AND appointment_date = CURDATE()',
+                [doc.id]
+            );
+
+            result.push({
+                doctor_id: doc.id,
+                doctor_name: `Dr. ${doc.first_name} ${doc.last_name}`,
+                specialty: doc.specialty,
+                total_today: Number(total_today),
+                waiting:     counts.WAITING,
+                in_progress: counts.IN_PROGRESS,
+                completed:   counts.COMPLETED,
+                missed:      counts.MISSED,
+                queue,
+            });
+        }
+
+        res.json(result);
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Server error' });

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,0 +1,8 @@
+export const API = import.meta.env.VITE_API_URL ?? 'http://localhost:5001';
+
+export function authedHeaders(body = false) {
+    const token = localStorage.getItem('hs_token') ?? '';
+    const headers = { Authorization: `Bearer ${token}` };
+    if (body) headers['Content-Type'] = 'application/json';
+    return headers;
+}

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,34 +1,133 @@
-import React, { useState, useEffect } from 'react';
-import { Users, Calendar, Stethoscope, Activity } from 'lucide-react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Users, Calendar, Stethoscope, CheckCircle, Clock, Activity } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { API, authedHeaders } from '../config/api';
 
 const StatCard = ({ title, value, icon: Icon, color, onClick }) => (
     <button
         onClick={onClick}
-        className="bg-white p-6 rounded-2xl shadow-sm border border-gray-100 flex items-start justify-between hover:shadow-md transition-all text-left w-full group"
+        className={`bg-white p-5 rounded-2xl shadow-sm border border-gray-100 flex items-start justify-between hover:shadow-md transition-all text-left w-full group ${onClick ? 'cursor-pointer' : 'cursor-default'}`}
     >
         <div>
             <p className="text-sm font-medium text-gray-500 mb-1">{title}</p>
-            <h3 className="text-4xl font-bold text-gray-800">{value}</h3>
+            <h3 className="text-3xl font-bold text-gray-800">{value}</h3>
         </div>
         <div className={`p-3 rounded-xl ${color} group-hover:scale-110 transition-transform`}>
-            <Icon size={24} />
+            <Icon size={22} />
         </div>
     </button>
 );
 
+const QueueBadge = ({ label, count, bg, text }) => (
+    <div className={`flex flex-col items-center px-3 py-1.5 rounded-lg ${bg}`}>
+        <span className={`text-lg font-bold ${text}`}>{count}</span>
+        <span className={`text-xs font-medium ${text} opacity-80`}>{label}</span>
+    </div>
+);
+
+const DoctorQueueCard = ({ data }) => {
+    const total = data.waiting + data.in_progress + data.completed + data.missed;
+    const completedPct = total > 0 ? Math.round((data.completed / total) * 100) : 0;
+
+    return (
+        <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-5">
+            <div className="flex items-start justify-between mb-3">
+                <div>
+                    <h4 className="font-bold text-gray-900">{data.doctor_name}</h4>
+                    <p className="text-sm text-gray-500">{data.specialty}</p>
+                </div>
+                <span className="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded-full">
+                    {data.total_today} today
+                </span>
+            </div>
+
+            <div className="flex gap-2 mb-4">
+                <QueueBadge label="Waiting"  count={data.waiting}     bg="bg-yellow-50"  text="text-yellow-700" />
+                <QueueBadge label="Active"   count={data.in_progress} bg="bg-blue-50"    text="text-blue-700" />
+                <QueueBadge label="Done"     count={data.completed}   bg="bg-green-50"   text="text-green-700" />
+                <QueueBadge label="Missed"   count={data.missed}      bg="bg-red-50"     text="text-red-600" />
+            </div>
+
+            {total > 0 && (
+                <div className="mb-4">
+                    <div className="flex justify-between text-xs text-gray-400 mb-1">
+                        <span>Progress</span>
+                        <span>{completedPct}%</span>
+                    </div>
+                    <div className="w-full bg-gray-100 rounded-full h-2">
+                        <div
+                            className="bg-green-500 h-2 rounded-full transition-all duration-500"
+                            style={{ width: `${completedPct}%` }}
+                        />
+                    </div>
+                </div>
+            )}
+
+            {data.queue.length > 0 && (
+                <div className="space-y-1.5 max-h-40 overflow-y-auto">
+                    {data.queue.map(q => (
+                        <div key={q.queue_id} className="flex items-center justify-between text-sm bg-gray-50 rounded-lg px-3 py-2">
+                            <div className="flex items-center gap-2">
+                                <span className="font-mono text-xs bg-white border border-gray-200 rounded px-1.5 py-0.5 text-gray-600">
+                                    #{q.queue_number}
+                                </span>
+                                <span className="text-gray-700 font-medium">{q.patient_name}</span>
+                                {q.time_slot && (
+                                    <span className="text-gray-400 text-xs">{q.time_slot}</span>
+                                )}
+                            </div>
+                            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+                                q.queue_status === 'WAITING'     ? 'bg-yellow-100 text-yellow-700' :
+                                q.queue_status === 'IN_PROGRESS' ? 'bg-blue-100 text-blue-700' :
+                                q.queue_status === 'COMPLETED'   ? 'bg-green-100 text-green-700' :
+                                                                   'bg-red-100 text-red-600'
+                            }`}>
+                                {q.queue_status === 'IN_PROGRESS' ? 'Active' : q.queue_status.charAt(0) + q.queue_status.slice(1).toLowerCase()}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {data.queue.length === 0 && (
+                <p className="text-xs text-gray-400 text-center py-2">No queue entries yet today</p>
+            )}
+        </div>
+    );
+};
+
 const AdminDashboard = () => {
     const navigate = useNavigate();
-    const [stats, setStats] = useState({ total_doctors: 0, total_patients: 0, today_appointments: 0 });
-    const [isLoading, setIsLoading] = useState(true);
+    const [stats, setStats] = useState(null);
+    const [queueData, setQueueData] = useState([]);
+    const [statsLoading, setStatsLoading] = useState(true);
+    const [queueLoading, setQueueLoading] = useState(true);
+    const [lastUpdated, setLastUpdated] = useState(null);
 
     useEffect(() => {
-        fetch('http://localhost:5001/api/admin/stats')
-            .then(res => res.json())
+        fetch(`${API}/api/admin/stats`, { headers: authedHeaders() })
+            .then(r => r.json())
             .then(data => setStats(data))
             .catch(err => console.error(err))
-            .finally(() => setIsLoading(false));
+            .finally(() => setStatsLoading(false));
     }, []);
+
+    const fetchQueue = useCallback(() => {
+        fetch(`${API}/api/admin/queue-overview`, { headers: authedHeaders() })
+            .then(r => r.json())
+            .then(data => {
+                setQueueData(Array.isArray(data) ? data : []);
+                setLastUpdated(new Date());
+            })
+            .catch(err => console.error(err))
+            .finally(() => setQueueLoading(false));
+    }, []);
+
+    useEffect(() => {
+        fetchQueue();
+        const interval = setInterval(fetchQueue, 20000);
+        return () => clearInterval(interval);
+    }, [fetchQueue]);
 
     return (
         <div className="space-y-8 pb-10">
@@ -37,57 +136,155 @@ const AdminDashboard = () => {
                 <p className="text-gray-500 mt-1">Overview of the hospital system.</p>
             </div>
 
-            {isLoading ? (
-                <div className="text-center text-gray-400 animate-pulse py-10">Loading stats...</div>
-            ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                    <StatCard
-                        title="Total Doctors"
-                        value={stats.total_doctors}
-                        icon={Stethoscope}
-                        color="bg-blue-50 text-blue-600"
-                        onClick={() => navigate('/admin-users')}
-                    />
-                    <StatCard
-                        title="Total Patients"
-                        value={stats.total_patients}
-                        icon={Users}
-                        color="bg-green-50 text-green-600"
-                        onClick={() => navigate('/admin-users')}
-                    />
-                    <StatCard
-                        title="Today's Appointments"
-                        value={stats.today_appointments}
-                        icon={Calendar}
-                        color="bg-orange-50 text-orange-600"
-                        onClick={() => navigate('/admin-appointments')}
-                    />
-                </div>
+            {/* Overall stats */}
+            <section>
+                <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Overall</h2>
+                {statsLoading ? (
+                    <div className="text-center text-gray-400 animate-pulse py-6">Loading stats...</div>
+                ) : stats && (
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                        <StatCard
+                            title="Total Doctors"
+                            value={stats.total_doctors}
+                            icon={Stethoscope}
+                            color="bg-blue-50 text-blue-600"
+                            onClick={() => navigate('/admin-users')}
+                        />
+                        <StatCard
+                            title="Total Patients"
+                            value={stats.total_patients}
+                            icon={Users}
+                            color="bg-green-50 text-green-600"
+                            onClick={() => navigate('/admin-users')}
+                        />
+                        <StatCard
+                            title="All Appointments"
+                            value={stats.total_appointments}
+                            icon={Calendar}
+                            color="bg-purple-50 text-purple-600"
+                            onClick={() => navigate('/admin-appointments')}
+                        />
+                    </div>
+                )}
+            </section>
+
+            {/* Today's breakdown */}
+            <section>
+                <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Today's Appointments</h2>
+                {statsLoading ? (
+                    <div className="text-center text-gray-400 animate-pulse py-6">Loading...</div>
+                ) : stats && (
+                    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                        <StatCard
+                            title="Total Today"
+                            value={stats.today_total ?? 0}
+                            icon={Activity}
+                            color="bg-orange-50 text-orange-600"
+                            onClick={() => navigate('/admin-appointments')}
+                        />
+                        <StatCard
+                            title="Confirmed"
+                            value={stats.today_confirmed ?? 0}
+                            icon={CheckCircle}
+                            color="bg-blue-50 text-blue-600"
+                        />
+                        <StatCard
+                            title="Completed"
+                            value={stats.today_completed ?? 0}
+                            icon={CheckCircle}
+                            color="bg-green-50 text-green-600"
+                        />
+                        <StatCard
+                            title="Pending"
+                            value={stats.today_pending ?? 0}
+                            icon={Clock}
+                            color="bg-yellow-50 text-yellow-600"
+                        />
+                    </div>
+                )}
+            </section>
+
+            {/* Top doctors today */}
+            {stats?.top_doctors_today?.length > 0 && (
+                <section>
+                    <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Top Doctors Today</h2>
+                    <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+                        <table className="w-full text-sm">
+                            <thead className="bg-gray-50 text-gray-500 text-xs uppercase">
+                                <tr>
+                                    <th className="px-4 py-3 text-left">Doctor</th>
+                                    <th className="px-4 py-3 text-left">Specialty</th>
+                                    <th className="px-4 py-3 text-right">Appointments</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-50">
+                                {stats.top_doctors_today.map(d => (
+                                    <tr key={d.id} className="hover:bg-gray-50">
+                                        <td className="px-4 py-3 font-medium text-gray-800">Dr. {d.first_name} {d.last_name}</td>
+                                        <td className="px-4 py-3 text-gray-500">{d.specialty}</td>
+                                        <td className="px-4 py-3 text-right font-bold text-gray-800">{d.count}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
             )}
 
-            <div className="grid sm:grid-cols-2 gap-6">
-                <div
-                    onClick={() => navigate('/admin-users')}
-                    className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 cursor-pointer hover:shadow-md hover:border-primary/30 transition-all"
-                >
-                    <div className="flex items-center gap-4 mb-4">
-                        <div className="p-3 bg-primary-light text-primary rounded-xl"><Users size={24} /></div>
-                        <h3 className="text-lg font-bold text-gray-900">Manage Users</h3>
+            {/* Live queue overview (A3) */}
+            <section>
+                <div className="flex items-center justify-between mb-3">
+                    <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide">Today's Live Queue</h2>
+                    <div className="flex items-center gap-2 text-xs text-gray-400">
+                        <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse inline-block" />
+                        {lastUpdated
+                            ? `Updated ${lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`
+                            : 'Refreshing every 20s'}
                     </div>
-                    <p className="text-gray-500 text-sm">Add or remove doctors and patients from the system.</p>
                 </div>
 
-                <div
-                    onClick={() => navigate('/admin-appointments')}
-                    className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 cursor-pointer hover:shadow-md hover:border-primary/30 transition-all"
-                >
-                    <div className="flex items-center gap-4 mb-4">
-                        <div className="p-3 bg-green-50 text-green-600 rounded-xl"><Calendar size={24} /></div>
-                        <h3 className="text-lg font-bold text-gray-900">All Appointments</h3>
+                {queueLoading ? (
+                    <div className="text-center text-gray-400 animate-pulse py-10">Loading queue data...</div>
+                ) : queueData.length === 0 ? (
+                    <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-10 text-center text-gray-400">
+                        No appointments scheduled for today yet.
                     </div>
-                    <p className="text-gray-500 text-sm">View all appointments across all doctors with patient symptoms.</p>
+                ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+                        {queueData.map(d => (
+                            <DoctorQueueCard key={d.doctor_id} data={d} />
+                        ))}
+                    </div>
+                )}
+            </section>
+
+            {/* Quick actions */}
+            <section>
+                <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-3">Quick Actions</h2>
+                <div className="grid sm:grid-cols-2 gap-5">
+                    <div
+                        onClick={() => navigate('/admin-users')}
+                        className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 cursor-pointer hover:shadow-md hover:border-primary/30 transition-all"
+                    >
+                        <div className="flex items-center gap-4 mb-3">
+                            <div className="p-3 bg-primary-light text-primary rounded-xl"><Users size={22} /></div>
+                            <h3 className="text-lg font-bold text-gray-900">Manage Users</h3>
+                        </div>
+                        <p className="text-gray-500 text-sm">Add or remove doctors and patients from the system.</p>
+                    </div>
+
+                    <div
+                        onClick={() => navigate('/admin-appointments')}
+                        className="bg-white rounded-2xl border border-gray-100 shadow-sm p-6 cursor-pointer hover:shadow-md hover:border-primary/30 transition-all"
+                    >
+                        <div className="flex items-center gap-4 mb-3">
+                            <div className="p-3 bg-green-50 text-green-600 rounded-xl"><Calendar size={22} /></div>
+                            <h3 className="text-lg font-bold text-gray-900">All Appointments</h3>
+                        </div>
+                        <p className="text-gray-500 text-sm">View all appointments across all doctors with patient symptoms.</p>
+                    </div>
                 </div>
-            </div>
+            </section>
         </div>
     );
 };


### PR DESCRIPTION
## Summary

- **A4** — Extended `GET /api/admin/stats` with full today breakdown: `today_total`, `today_confirmed`, `today_completed`, `today_pending`, `today_cancelled`, and `top_doctors_today` (top 5 by appointment count)
- **A3** — New `GET /api/admin/queue-overview` endpoint grouping today's appointments per doctor with WAITING/IN_PROGRESS/COMPLETED/MISSED counts and individual queue entries
- **AdminDashboard.jsx** fully rewritten with:
  - 3 overall stat cards (Total Doctors, Total Patients, All Appointments)
  - 4 today breakdown cards (Total Today, Confirmed, Completed, Pending)
  - Top Doctors Today leaderboard table
  - Today's Live Queue section: per-doctor cards with status badges, progress bar, scrollable patient list — auto-refreshes every 20s
- Created `frontend/src/config/api.js` with `API` base URL and `authedHeaders()` helper

## Test plan

- [ ] Login as admin (`admin@hospital.com` / `admin123`)
- [ ] Verify 7 stat cards render with real DB counts
- [ ] Verify Top Doctors Today table appears when there are today's appointments
- [ ] Verify Live Queue section shows per-doctor cards with correct status counts
- [ ] Wait 20 seconds — confirm "Updated HH:MM:SS" timestamp refreshes automatically
- [ ] Update a queue token in doctor dashboard — confirm admin live queue reflects change within 20s
- [ ] Verify empty state message when no appointments today

🤖 Generated with [Claude Code](https://claude.com/claude-code)