### PR TITLE
feat(D2): Doctor can block specific dates (vacation, unavailability)

### DIFF
--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -64,6 +64,16 @@ CREATE TABLE IF NOT EXISTS live_queue (
     FOREIGN KEY (appointment_id) REFERENCES appointments(id)
 );
 
+-- 6. Doctor Blocked Dates Table
+CREATE TABLE IF NOT EXISTS doctor_blocked_dates (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    doctor_id INT NOT NULL,
+    blocked_date DATE NOT NULL,
+    reason VARCHAR(255),
+    UNIQUE KEY unique_doctor_date (doctor_id, blocked_date),
+    FOREIGN KEY (doctor_id) REFERENCES doctors(id) ON DELETE CASCADE
+);
+
 -- Insert Mock Users (passwords stored as plain text for dev/educational use)
 INSERT IGNORE INTO users (id, email, password_hash, role) VALUES
 (1, 'patient@example.com', 'patient123', 'PATIENT'),
@@ -92,6 +102,7 @@ INSERT IGNORE INTO live_queue (appointment_id, queue_number, status, estimated_t
 -- -------------------------------------------------------
 -- Run the following ALTER if DB already exists (one-time):
 -- ALTER TABLE appointments ADD COLUMN IF NOT EXISTS symptoms TEXT AFTER time_slot;
+-- CREATE TABLE IF NOT EXISTS doctor_blocked_dates (id INT AUTO_INCREMENT PRIMARY KEY, doctor_id INT NOT NULL, blocked_date DATE NOT NULL, reason VARCHAR(255), UNIQUE KEY unique_doctor_date (doctor_id, blocked_date), FOREIGN KEY (doctor_id) REFERENCES doctors(id) ON DELETE CASCADE);
 -- UPDATE users SET password_hash = 'patient123' WHERE id = 1;
 -- UPDATE users SET password_hash = 'doctor123' WHERE id IN (2, 3);
 -- INSERT IGNORE INTO users (id, email, password_hash, role) VALUES (10, 'admin@hospital.com', 'admin123', 'ADMIN');

--- a/backend/src/routes/doctors.js
+++ b/backend/src/routes/doctors.js
@@ -135,4 +135,51 @@ router.get('/:id/queue', async (req, res) => {
     }
 });
 
+// GET /api/doctors/:id/blocked-dates — list all blocked dates for a doctor
+router.get('/:id/blocked-dates', async (req, res) => {
+    try {
+        const [rows] = await db.query(
+            'SELECT id, blocked_date, reason FROM doctor_blocked_dates WHERE doctor_id = ? ORDER BY blocked_date ASC',
+            [req.params.id]
+        );
+        res.json(rows);
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// POST /api/doctors/:id/blocked-dates — block a specific date
+router.post('/:id/blocked-dates', async (req, res) => {
+    try {
+        const { date, reason } = req.body;
+        if (!date) return res.status(400).json({ message: 'date is required' });
+        const [result] = await db.query(
+            'INSERT INTO doctor_blocked_dates (doctor_id, blocked_date, reason) VALUES (?, ?, ?)',
+            [req.params.id, date, reason || null]
+        );
+        res.status(201).json({ id: result.insertId, blocked_date: date, reason: reason || null });
+    } catch (error) {
+        if (error.code === 'ER_DUP_ENTRY') {
+            return res.status(409).json({ message: 'This date is already blocked' });
+        }
+        console.error(error);
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// DELETE /api/doctors/:id/blocked-dates/:dateId — unblock a date
+router.delete('/:id/blocked-dates/:dateId', async (req, res) => {
+    try {
+        await db.query(
+            'DELETE FROM doctor_blocked_dates WHERE id = ? AND doctor_id = ?',
+            [req.params.dateId, req.params.id]
+        );
+        res.json({ message: 'Date unblocked' });
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: 'Server error' });
+    }
+});
+
 module.exports = router;

--- a/frontend/src/pages/BookAppointment.jsx
+++ b/frontend/src/pages/BookAppointment.jsx
@@ -62,6 +62,7 @@ const BookAppointment = () => {
     const [isBooked, setIsBooked] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [currentMonth, setCurrentMonth] = useState(new Date());
+    const [blockedDates, setBlockedDates] = useState(new Set());
 
     useEffect(() => {
         fetch('http://localhost:5001/api/doctors')
@@ -73,8 +74,22 @@ const BookAppointment = () => {
             .catch(err => console.error(err));
     }, []);
 
-    // Reset when doctor changes
-    useEffect(() => { setSelectedSlot(null); setSlotCounts({}); }, [selectedDoctor]);
+    // Reset when doctor changes and fetch their blocked dates
+    useEffect(() => {
+        setSelectedSlot(null);
+        setSlotCounts({});
+        setBlockedDates(new Set());
+        if (!selectedDoctor) return;
+        fetch(`http://localhost:5001/api/doctors/${selectedDoctor}/blocked-dates`)
+            .then(r => r.json())
+            .then(data => {
+                if (Array.isArray(data)) {
+                    // blocked_date comes as "YYYY-MM-DDT00:00:00.000Z" — normalise to YYYY-MM-DD
+                    setBlockedDates(new Set(data.map(d => d.blocked_date.slice(0, 10))));
+                }
+            })
+            .catch(() => {});
+    }, [selectedDoctor]);
 
     // Fetch current booking counts whenever doctor + date are both set
     useEffect(() => {
@@ -226,19 +241,22 @@ const BookAppointment = () => {
                                 const isPast  = d < new Date(today.getFullYear(), today.getMonth(), today.getDate());
                                 const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(date).padStart(2, '0')}`;
                                 const closed  = !isPast && isDocClosed(dateStr);
-                                const disabled = isPast || closed;
+                                const isBlocked = !isPast && blockedDates.has(dateStr);
+                                const disabled = isPast || closed || isBlocked;
                                 return (
                                     <button
                                         key={date}
                                         disabled={disabled}
                                         onClick={() => setSelectedDate(dateStr)}
-                                        title={closed ? 'Doctor unavailable' : undefined}
+                                        title={closed ? 'Doctor unavailable' : isBlocked ? 'Doctor blocked this date' : undefined}
                                         className={`w-10 h-10 mx-auto rounded-full flex items-center justify-center text-sm font-medium transition-colors
                                             ${selectedDate === dateStr
                                                 ? 'bg-primary text-white shadow-md shadow-primary/30'
-                                                : disabled
-                                                    ? 'text-gray-300 cursor-not-allowed'
-                                                    : 'text-gray-700 hover:bg-gray-100'
+                                                : isBlocked
+                                                    ? 'bg-red-50 text-red-300 cursor-not-allowed line-through'
+                                                    : disabled
+                                                        ? 'text-gray-300 cursor-not-allowed'
+                                                        : 'text-gray-700 hover:bg-gray-100'
                                             }`}
                                     >
                                         {date}

--- a/frontend/src/pages/DoctorProfileEdit.jsx
+++ b/frontend/src/pages/DoctorProfileEdit.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Camera, Save, Clock, CheckCircle2, AlertCircle, User, MapPin, Award, BookOpen } from 'lucide-react';
+import { Camera, Save, Clock, CheckCircle2, AlertCircle, User, MapPin, Award, BookOpen, CalendarX, Plus, Trash2 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 const DAYS = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
@@ -32,6 +32,10 @@ const DoctorProfileEdit = () => {
     const [savingAvail, setSavingAvail] = useState(false);
     const [profileMsg, setProfileMsg] = useState(null);  // {type:'success'|'error', text}
     const [availMsg, setAvailMsg]     = useState(null);
+    const [blockedDates, setBlockedDates] = useState([]);
+    const [newBlockDate, setNewBlockDate] = useState('');
+    const [newBlockReason, setNewBlockReason] = useState('');
+    const [blockMsg, setBlockMsg] = useState(null);
 
     // Load current doctor data
     useEffect(() => {
@@ -60,6 +64,16 @@ const DoctorProfileEdit = () => {
             .catch(err => console.error(err))
             .finally(() => setIsLoading(false));
     }, [user?.id]);
+
+    const fetchBlockedDates = () => {
+        if (!user?.id) return;
+        fetch(`http://localhost:5001/api/doctors/${user.id}/blocked-dates`)
+            .then(r => r.json())
+            .then(data => setBlockedDates(Array.isArray(data) ? data : []))
+            .catch(err => console.error(err));
+    };
+
+    useEffect(() => { fetchBlockedDates(); }, [user?.id]);
 
     // Handle photo file pick — convert to base64
     const handlePhotoChange = (e) => {
@@ -132,6 +146,42 @@ const DoctorProfileEdit = () => {
             showMsg(setAvailMsg, { type: 'error', text: 'Failed to save schedule. Try again.' });
         } finally {
             setSavingAvail(false);
+        }
+    };
+
+    const addBlockedDate = async () => {
+        if (!newBlockDate) {
+            setBlockMsg({ type: 'error', text: 'Please select a date to block.' });
+            return;
+        }
+        setBlockMsg(null);
+        try {
+            const res = await fetch(`http://localhost:5001/api/doctors/${user.id}/blocked-dates`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ date: newBlockDate, reason: newBlockReason || null }),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                throw new Error(err.message || 'Failed');
+            }
+            setNewBlockDate('');
+            setNewBlockReason('');
+            fetchBlockedDates();
+            showMsg(setBlockMsg, { type: 'success', text: 'Date blocked successfully.' });
+        } catch (err) {
+            setBlockMsg({ type: 'error', text: err.message });
+        }
+    };
+
+    const removeBlockedDate = async (id) => {
+        try {
+            await fetch(`http://localhost:5001/api/doctors/${user.id}/blocked-dates/${id}`, {
+                method: 'DELETE',
+            });
+            setBlockedDates(prev => prev.filter(d => d.id !== id));
+        } catch (err) {
+            console.error(err);
         }
     };
 
@@ -348,6 +398,70 @@ const DoctorProfileEdit = () => {
                         {savingAvail ? 'Saving...' : 'Save Schedule'}
                     </button>
                 </div>
+            </div>
+
+            {/* ── BLOCKED DATES ── */}
+            <div className="bg-white rounded-3xl border border-gray-100 shadow-sm p-8">
+                <h2 className="text-lg font-bold text-gray-900 mb-2 flex items-center gap-2">
+                    <CalendarX size={20} className="text-red-500" /> Blocked Dates
+                </h2>
+                <p className="text-sm text-gray-500 mb-6">Block specific dates where you are unavailable (vacation, conference, etc.). Patients cannot book on these dates.</p>
+
+                {blockMsg && (
+                    <div className={`mb-5 p-3 rounded-xl flex items-center gap-2 text-sm font-medium ${blockMsg.type === 'success' ? 'bg-green-50 text-green-700 border border-green-200' : 'bg-red-50 text-red-700 border border-red-200'}`}>
+                        {blockMsg.type === 'success' ? <CheckCircle2 size={16} /> : <AlertCircle size={16} />}
+                        {blockMsg.text}
+                    </div>
+                )}
+
+                {/* Add new blocked date */}
+                <div className="flex flex-col sm:flex-row gap-3 mb-6 p-4 bg-gray-50 rounded-2xl border border-gray-100">
+                    <input
+                        type="date"
+                        value={newBlockDate}
+                        onChange={e => setNewBlockDate(e.target.value)}
+                        min={new Date().toISOString().split('T')[0]}
+                        className="border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white flex-shrink-0"
+                    />
+                    <input
+                        type="text"
+                        value={newBlockReason}
+                        onChange={e => setNewBlockReason(e.target.value)}
+                        placeholder="Reason (optional, e.g. Vacation)"
+                        className="flex-1 border border-gray-200 rounded-xl px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30 bg-white"
+                    />
+                    <button
+                        onClick={addBlockedDate}
+                        className="flex items-center gap-2 px-5 py-2.5 bg-red-500 text-white font-semibold text-sm rounded-xl hover:bg-red-600 transition-colors flex-shrink-0"
+                    >
+                        <Plus size={16} /> Block Date
+                    </button>
+                </div>
+
+                {/* Existing blocked dates */}
+                {blockedDates.length === 0 ? (
+                    <p className="text-sm text-gray-400 text-center py-4">No dates blocked. You are fully available.</p>
+                ) : (
+                    <div className="space-y-2">
+                        {blockedDates.map(d => (
+                            <div key={d.id} className="flex items-center justify-between px-4 py-3 bg-red-50 border border-red-100 rounded-xl">
+                                <div>
+                                    <p className="text-sm font-semibold text-red-700">
+                                        {new Date(d.blocked_date).toLocaleDateString('en-US', { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' })}
+                                    </p>
+                                    {d.reason && <p className="text-xs text-red-500 mt-0.5">{d.reason}</p>}
+                                </div>
+                                <button
+                                    onClick={() => removeBlockedDate(d.id)}
+                                    className="p-2 text-red-400 hover:text-red-600 hover:bg-red-100 rounded-lg transition-colors"
+                                    title="Unblock this date"
+                                >
+                                    <Trash2 size={16} />
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

- **Schema**: New `doctor_blocked_dates` table — `(id, doctor_id FK, blocked_date DATE UNIQUE per doctor, reason VARCHAR)`. Migration `CREATE TABLE` statement provided in `schema.sql` comments.
- **3 new API endpoints on `doctors.js`**:
  - `GET /api/doctors/:id/blocked-dates` — returns array of `{ id, blocked_date, reason }`
  - `POST /api/doctors/:id/blocked-dates` — adds `{ date, reason }`, returns 409 if already blocked
  - `DELETE /api/doctors/:id/blocked-dates/:dateId` — removes a blocked date entry
- **DoctorProfileEdit**: New "Blocked Dates" section card at the bottom of the profile page. Doctor selects a date + optional reason, clicks "Block Date". Existing blocked dates shown as a list with trash icon to unblock. Success/error feedback messages included.
- **BookAppointment**: When doctor is selected, blocked dates are fetched. In the calendar, blocked dates render as red with strikethrough (line-through) and are unclickable. Tooltip shows "Doctor blocked this date".

## Test plan

- [ ] Login as doctor → go to My Profile
- [ ] Scroll to "Blocked Dates" section — verify empty state message
- [ ] Block a future date with a reason (e.g. "Vacation") — verify it appears in the list
- [ ] Try to block the same date again — verify "already blocked" error
- [ ] Click trash icon on a blocked date — verify it disappears
- [ ] Login as patient → go to Book Appointment
- [ ] Select the same doctor — confirm the blocked date appears red and struck through in calendar
- [ ] Hover blocked date — confirm tooltip "Doctor blocked this date"
- [ ] Confirm blocked date cannot be clicked or selected
- [ ] Run `schema.sql` fresh — confirm `doctor_blocked_dates` table created

🤖 Generated with [Claude Code](https://claude.com/claude-code)