### PR TITLE
fix: sanitize empty vitals and handle clinical assessment submission failure on dashboard

### DIFF
--- a/frontend/src/pages/DoctorDashboard.jsx
+++ b/frontend/src/pages/DoctorDashboard.jsx
@@ -334,6 +334,11 @@ const DoctorDashboard = () => {
         try {
             await apiClient.patch(`/api/appointments/queue/${queueId}/status`, { status: newStatus, ...extra });
             setQueue(prev => prev.map(q => q.queue_id === queueId ? { ...q, queue_status: newStatus } : q));
+        } catch (err) {
+            console.error('Failed to update queue status:', err);
+            const errMsg = err.response?.data?.message || err.message || 'Failed to update status. Please check your clinical inputs.';
+            alert(errMsg);
+            throw err;
         } finally { setUpdatingId(null); }
     };
 
@@ -346,9 +351,32 @@ const DoctorDashboard = () => {
                     item={notesModal.item}
                     saving={updatingId === notesModal.queueId}
                     onSave={async (form) => {
-                        await updateQueueStatus(notesModal.queueId, 'COMPLETED', form);
-                        setNotesModal(null);
-                        fetchData();
+                        // Clean up form to match backend schemas and convert blank strings to appropriate types
+                        const cleanedForm = { ...form };
+                        if (cleanedForm.diagnosis === '') cleanedForm.diagnosis = null;
+                        if (cleanedForm.notes === '') cleanedForm.notes = null;
+                        if (cleanedForm.prescription === '') cleanedForm.prescription = null;
+                        if (cleanedForm.follow_up_date === '') cleanedForm.follow_up_date = null;
+
+                        if (cleanedForm.vitals) {
+                            const cleanedVitals = {};
+                            let hasVitals = false;
+                            Object.entries(cleanedForm.vitals).forEach(([key, val]) => {
+                                if (val !== '' && val !== null && val !== undefined) {
+                                    cleanedVitals[key] = Number(val);
+                                    hasVitals = true;
+                                }
+                            });
+                            cleanedForm.vitals = hasVitals ? cleanedVitals : null;
+                        }
+
+                        try {
+                            await updateQueueStatus(notesModal.queueId, 'COMPLETED', cleanedForm);
+                            setNotesModal(null);
+                            fetchData();
+                        } catch (err) {
+                            console.error('Modal save failed:', err);
+                        }
                     }}
                     onClose={() => setNotesModal(null)}
                 />


### PR DESCRIPTION
## Description
This PR resolves the issue where clicking the 'Verify & Complete' button in the Clinical Assessment / Complete Analysis modal leaves the boxes blank and fails to submit/complete.

### Resolved Issues
1. **Empty String Validation Conflict**: The Joi schema expects `Joi.number().allow(null)` for the patient's vitals. But since the frontend modal initializes vital inputs as empty strings (`""`), blank forms sent `""` instead of `null` or a number. This triggered a `400 Bad Request` validation error from the backend.
2. **Missing UI Error Handling**: Since the request was not caught inside the dashboard status handler, the rejection failed silently in the background, leaving the modal stuck open.
3. **Data Sanitization**: Added automatic casting of vital metrics to actual `Number` types and cleans up blank string values to `null` before sending them to the backend API.
4. **Try/Catch Alerts**: Wrapped the patch handler in a `try/catch` wrapper that triggers a browser alert on failure (showing Joi validation messages, like BP or Heart Rate range bounds) and keeps the modal open to prevent data loss.