### PR TITLE
Sprint 1: Environment & Central Config Hardening

### DIFF
--- a/backend/src/config/validateEnv.js
+++ b/backend/src/config/validateEnv.js
@@ -22,9 +22,17 @@ function validateEnv() {
     } else {
         // Novel: Verify JWT Secret Strength
         const jwtSecret = process.env.JWT_SECRET;
-        if (jwtSecret === 'hs_jwt_super_secret_change_in_production_2024' || jwtSecret.length < 32) {
-            console.warn('\x1b[33m%s\x1b[0m', '⚠️  SECURITY WARNING: JWT_SECRET is using a default value or is too weak.');
-            console.warn('\x1b[33m%s\x1b[0m', '   For production, please use a secure, random string (min 32 characters).');
+        const isDefaultSecret = jwtSecret === 'hs_jwt_super_secret_change_in_production_2024';
+        
+        if (isDefaultSecret || jwtSecret.length < 32) {
+            if (process.env.NODE_ENV === 'production') {
+                console.error('\x1b[31m%s\x1b[0m', 'FATAL SECURITY ERROR: JWT_SECRET is using the default placeholder value or is too weak in production.');
+                console.error('\x1b[31m%s\x1b[0m', 'Startup blocked for safety. Please configure a secure, random string (min 32 characters).');
+                process.exit(1);
+            } else {
+                console.warn('\x1b[33m%s\x1b[0m', '⚠️  SECURITY WARNING: JWT_SECRET is using a default value or is too weak.');
+                console.warn('\x1b[33m%s\x1b[0m', '   For production, please use a secure, random string (min 32 characters).');
+            }
         } else {
             console.log('\x1b[32m%s\x1b[0m', '✓ Security: JWT Secret strength verified.');
         }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -102,8 +102,7 @@ const whitelist = new Set([
     ...(process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : []),
     process.env.APP_URL,
     process.env.FRONTEND_URL,
-    'http://localhost:5173',
-    'http://127.0.0.1:5173'
+    ...(process.env.NODE_ENV !== 'production' ? ['http://localhost:5173', 'http://127.0.0.1:5173'] : [])
 ].map(normalizeOrigin).filter(Boolean));
 
 const corsOptions = {
@@ -117,16 +116,13 @@ const corsOptions = {
         if (whitelist.has(normalizedOrigin)) return callback(null, true);
         
         // 2. Allow all localhost/127.0.0.1 variants for development
-        if (/^http:\/\/localhost:\d+$/.test(origin) || /^http:\/\/127\.0\.0\.1:\d+$/.test(origin)) {
-            return callback(null, true);
+        if (process.env.NODE_ENV !== 'production') {
+            if (/^http:\/\/localhost:\d+$/.test(origin) || /^http:\/\/127\.0\.0\.1:\d+$/.test(origin)) {
+                return callback(null, true);
+            }
         }
         
-        // 3. Allow all Vercel and Hugging Face deployments
-        if (/\.vercel\.app$/.test(origin) || /\.hf\.space$/.test(origin)) {
-            return callback(null, true);
-        }
-        
-        // 4. In development, be permissive if needed
+        // 3. In development, be permissive if needed
         if (process.env.NODE_ENV !== 'production') return callback(null, true);
 
         callback(new Error('Not allowed by CORS'));

--- a/backend/src/services/paymentService.js
+++ b/backend/src/services/paymentService.js
@@ -1,5 +1,13 @@
-const stripeKey = process.env.STRIPE_SECRET_KEY || 'sk_test_mock';
-const stripe = require('stripe')(stripeKey);
+const stripeKey = process.env.STRIPE_SECRET_KEY;
+
+if (!stripeKey) {
+    if (process.env.NODE_ENV === 'production') {
+        throw new Error('FATAL CONFIGURATION ERROR: STRIPE_SECRET_KEY environment variable is missing in production.');
+    }
+    console.warn('⚠️ WARNING: STRIPE_SECRET_KEY is not defined. Using sk_test_mock fallback for development.');
+}
+
+const stripe = require('stripe')(stripeKey || 'sk_test_mock');
 const db = require('../config/db');
 
 class PaymentService {

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,7 +1,7 @@
 // Central API base URL.
 // Set VITE_API_URL in your .env file to point to the correct backend.
 // Falls back to localhost:5001 for local development so nothing breaks without a .env.
-export const API = import.meta.env.VITE_API_URL || 'https://archittmittal-backend-patientappointment.hf.space';
+export const API = import.meta.env.VITE_API_URL || (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:7860');
 export const API_URL = `${API}/api`;
 
 /** Returns headers for an authenticated request.

--- a/frontend/src/pages/BookAppointment.jsx
+++ b/frontend/src/pages/BookAppointment.jsx
@@ -202,23 +202,29 @@ const BookAppointment = () => {
     };
 
     const handleBook = async () => {
+        if (!user || !user.id) {
+            alert('Please sign in to book an appointment.');
+            return;
+        }
         setIsSubmitting(true);
         try {
             const data = await apiClient.post('/api/appointments/book', { 
-                patientId: user.id, 
                 doctorId: selectedDoctorId, 
                 date: selectedDate, 
                 timeSlot: selectedSlot, 
                 symptoms: symptoms || null 
             });
-            if (!data.error) {
+            // apiClient returns [] on network errors — treat arrays as failure
+            if (data && !Array.isArray(data) && !data.error && data.appointmentId) {
                 setBookingResult(data);
                 setIsBooked(true);
-            } else {
+            } else if (data && data.error) {
                 const errMsg = data.detail 
                     ? `${data.message}: ${data.detail}` 
                     : (data.message || 'Unable to complete booking. Please try again.');
                 alert(errMsg);
+            } else {
+                alert('Unable to complete booking. Please check your connection and try again.');
             }
         } catch (err) {
             console.error('[Booking] Connection error:', err);


### PR DESCRIPTION
This Pull Request implements the security hardening and configuration extraction deliverables defined in **Sprint 1** of our backlog.

### 🛠️ Completed Remediation Items:
- **[HC-001]**: Hardened `validateEnv.js` to block system startup in production with an exit code `1` if `JWT_SECRET` is set to the default placeholder.
- **[HC-002]** / **[SEC-001]**: Confirmed `.env` secrets are excluded from Git indexing and verified `.gitignore` rules.
- **[HC-003]**: Forced dynamic Stripe secret keys checking to throw runtime configuration errors on mock key fallbacks in production.
- **[HC-007]**: Replaced hardcoded Hugging Face space URLs with dynamic browser origin fallbacks (`window.location.origin`) for self-hosting.
- **[HC-006]** / **[SEC-008]**: Restructured CORS whitelists in `server.js` to run local dev hosts in non-production modes, and completely removed platform subdomain wildcards (`*.vercel.app` and `*.hf.space`) to prevent domain-bypass exploits.

### 📊 Automatically Resolves & Closes Issues:
- Closes #167
- Closes #168
- Closes #169
- Closes #172
- Closes #177
- Closes #179
- Closes #206
