### PR TITLE
perf(admin): Sprint 7 — pagination, column narrowing, status casing n…

### DIFF
--- a/backend/src/jobs/reminderJobs.js
+++ b/backend/src/jobs/reminderJobs.js
@@ -35,7 +35,8 @@ const initCronJobs = () => {
                 FROM appointments a
                 JOIN doctors d ON a.doctor_id = d.id
                 WHERE a.appointment_date = CURDATE() 
-                AND a.status = 'CONFIRMED'
+                AND a.status = 'confirmed'
+                -- BUG-005: was 'CONFIRMED' — statuses are stored lowercase at booking time
             `;
 
             const [appointments] = await db.query(query);
@@ -68,7 +69,8 @@ const initCronJobs = () => {
                 FROM appointments a
                 JOIN doctors d ON a.doctor_id = d.id
                 WHERE a.appointment_date = CURDATE()
-                AND a.status = 'CONFIRMED'
+                AND a.status = 'confirmed'
+                -- BUG-005: was 'CONFIRMED' — statuses are stored lowercase at booking time
             `;
 
             const [appointments] = await db.query(query);

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -39,6 +39,14 @@ const usersQuerySchema = Joi.object({
     order: Joi.string().valid('ASC', 'DESC', 'asc', 'desc').default('ASC')
 });
 
+// DB-003: Validation schema for paginated appointments listing
+const appointmentsQuerySchema = Joi.object({
+    page: Joi.number().integer().min(1).default(1),
+    limit: Joi.number().integer().min(1).max(100).default(20),
+    status: Joi.string().valid('confirmed', 'pending', 'completed', 'cancelled', 'scheduled', 'ALL').default('ALL'),
+    date: Joi.string().isoDate().allow('', null)
+});
+
 // All admin routes require authentication + ADMIN role
 router.use(authenticate);
 router.use(requireRole('ADMIN'));
@@ -491,31 +499,98 @@ router.get('/patients/search', async (req, res) => {
  * @swagger
  * /api/admin/appointments:
  *   get:
- *     summary: Retrieve a list of all appointments in the system
+ *     summary: Retrieve a paginated list of all appointments in the system
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [confirmed, pending, completed, cancelled, scheduled, ALL]
+ *           default: ALL
+ *       - in: query
+ *         name: date
+ *         schema:
+ *           type: string
+ *           format: date
  *     responses:
  *       200:
- *         description: List of all appointments retrieved successfully
+ *         description: Paginated list of appointments retrieved successfully
  *       401:
  *         description: Unauthorized
  *       403:
  *         description: Forbidden (Requires ADMIN role)
  */
-router.get('/appointments', async (req, res) => {
+router.get('/appointments', validateRequest(appointmentsQuerySchema, 'query'), async (req, res) => {
     try {
-        const [rows] = await db.query(`
-            SELECT a.id, a.appointment_date, a.time_slot, a.symptoms, a.status, a.created_at,
-                   p.first_name AS patient_first, p.last_name AS patient_last,
-                   d.first_name AS doctor_first, d.last_name AS doctor_last,
-                   d.specialty, d.location_room
-            FROM appointments a
-            JOIN patients p ON a.patient_id = p.id
-            JOIN doctors d ON a.doctor_id = d.id
-            ORDER BY a.appointment_date DESC, a.created_at DESC
-        `);
-        res.json(rows);
+        const { page, limit, status, date } = req.query;
+        const offset = (page - 1) * limit;
+
+        // Build optional WHERE clauses
+        const conditions = [];
+        const filterParams = [];
+
+        // DB-003: status filter (ALL = no filter)
+        if (status && status !== 'ALL') {
+            conditions.push('LOWER(a.status) = ?');
+            filterParams.push(status.toLowerCase());
+        }
+
+        // DB-003: optional exact date filter
+        if (date) {
+            conditions.push('a.appointment_date = ?');
+            filterParams.push(date);
+        }
+
+        const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+        // Count query
+        const [countResult] = await db.query(
+            `SELECT COUNT(*) AS total
+             FROM appointments a
+             JOIN patients p ON a.patient_id = p.id
+             JOIN doctors d ON a.doctor_id = d.id
+             ${whereClause}`,
+            filterParams
+        );
+        const total = countResult[0].total;
+
+        // Data query with pagination
+        const [rows] = await db.query(
+            `SELECT a.id, a.appointment_date, a.time_slot, a.symptoms, a.status, a.created_at,
+                    p.first_name AS patient_first, p.last_name AS patient_last,
+                    d.first_name AS doctor_first, d.last_name AS doctor_last,
+                    d.specialty, d.location_room
+             FROM appointments a
+             JOIN patients p ON a.patient_id = p.id
+             JOIN doctors d ON a.doctor_id = d.id
+             ${whereClause}
+             ORDER BY a.appointment_date DESC, a.created_at DESC
+             LIMIT ? OFFSET ?`,
+            [...filterParams, limit, offset]
+        );
+
+        res.json({
+            data: rows,
+            meta: {
+                total,
+                page,
+                limit,
+                total_pages: Math.ceil(total / limit)
+            }
+        });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Server error' });
@@ -546,13 +621,12 @@ router.get('/stats', async (req, res) => {
                 (SELECT COUNT(*) FROM patients) AS total_patients,
                 (SELECT COUNT(*) FROM appointments) AS total_appointments,
                 COUNT(CASE WHEN appointment_date = CURDATE() THEN 1 END) AS today_total,
-                COUNT(CASE WHEN appointment_date = CURDATE() AND status = 'CONFIRMED' THEN 1 END) AS today_confirmed,
-                COUNT(CASE WHEN appointment_date = CURDATE() AND status = 'COMPLETED' THEN 1 END) AS today_completed,
-                COUNT(CASE WHEN appointment_date = CURDATE() AND status = 'PENDING' THEN 1 END) AS today_pending,
-                COUNT(CASE WHEN appointment_date = CURDATE() AND status = 'CANCELLED' THEN 1 END) AS today_cancelled
+                COUNT(CASE WHEN appointment_date = CURDATE() AND LOWER(status) = 'confirmed' THEN 1 END) AS today_confirmed,
+                COUNT(CASE WHEN appointment_date = CURDATE() AND LOWER(status) = 'completed' THEN 1 END) AS today_completed,
+                COUNT(CASE WHEN appointment_date = CURDATE() AND LOWER(status) = 'pending' THEN 1 END) AS today_pending,
+                COUNT(CASE WHEN appointment_date = CURDATE() AND LOWER(status) = 'cancelled' THEN 1 END) AS today_cancelled
             FROM appointments
         `);
-        
         const stats = statsRows[0];
 
         // Top 5 doctors by appointment count today

--- a/backend/src/routes/appointments.js
+++ b/backend/src/routes/appointments.js
@@ -670,7 +670,8 @@ router.patch('/:id/cancel', authenticate, async (req, res) => {
             }
         }
 
-        if (!['CONFIRMED', 'PENDING', 'confirmed', 'pending', 'scheduled'].includes(appt.status)) {
+        // BUG-008: Use LOWER() to normalize before comparison — statuses are stored lowercase
+        if (!['confirmed', 'pending', 'scheduled'].includes(String(appt.status).toLowerCase())) {
             return res.status(400).json({ message: `Cannot cancel appointment with status ${appt.status}` });
         }
 

--- a/backend/src/routes/doctors.js
+++ b/backend/src/routes/doctors.js
@@ -33,6 +33,12 @@ const availabilitySchema = Joi.object({
     availability: Joi.object().required()
 });
 
+// DB-005: Pagination schema for the doctor's patient listing
+const patientsQuerySchema = Joi.object({
+    page: Joi.number().integer().min(1).default(1),
+    limit: Joi.number().integer().min(1).max(100).default(50)
+});
+
 const blockedDateSchema = Joi.object({
     date: Joi.string().isoDate().required(),
     reason: Joi.string().max(255).allow('', null)
@@ -87,9 +93,17 @@ const autofillSettingsSchema = Joi.object({
  *       404:
  *         description: Doctor not found
  */
+// DB-007: Explicit column list for the public doctor listing (excludes availability blob)
+const DOCTOR_LIST_COLUMNS = `
+    id, first_name, last_name, specialty, degree, experience_years,
+    location_room, image_url, about, consultation_fee, max_patients_per_slot, rating
+`;
+
 router.get('/', async (req, res) => {
     try {
-        const [rows] = await db.query('SELECT * FROM doctors');
+        // DB-007: Use explicit columns — availability is a potentially large JSON blob
+        // and is not needed for the doctor listing/search view.
+        const [rows] = await db.query(`SELECT ${DOCTOR_LIST_COLUMNS} FROM doctors`);
         res.json(rows);
     } catch (error) {
         console.error(error);
@@ -100,7 +114,12 @@ router.get('/', async (req, res) => {
 // GET /api/doctors/:id — single doctor (with availability)
 router.get('/:id', async (req, res) => {
     try {
-        const [rows] = await db.query('SELECT * FROM doctors WHERE id = ?', [req.params.id]);
+        // DB-007: Include availability here — the booking UI needs it for slot selection,
+        // but exclude password_hash and other internal columns.
+        const [rows] = await db.query(
+            `SELECT ${DOCTOR_LIST_COLUMNS}, availability FROM doctors WHERE id = ?`,
+            [req.params.id]
+        );
         if (rows.length === 0) return res.status(404).json({ message: 'Doctor not found' });
         res.json(rows[0]);
     } catch (error) {
@@ -210,24 +229,44 @@ router.get('/:id/reviews', async (req, res) => {
 });
 
 // GET /api/doctors/:id/patients — all patients with their appointments + symptoms
-router.get('/:id/patients', authenticate, requireRole('DOCTOR'), async (req, res) => {
+// DB-005: Paginated — default 50 per page to avoid unbounded dumps for high-volume doctors
+router.get('/:id/patients', authenticate, requireRole('DOCTOR'), validateRequest(patientsQuerySchema, 'query'), async (req, res) => {
     // Only the doctor themselves can view their patient list
     if (req.user.id != req.params.id) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
-        const [rows] = await db.query(`
-            SELECT a.id AS appointment_id, a.appointment_date, a.time_slot, a.symptoms, a.status,
-                   a.diagnosis, a.notes, a.prescription, a.follow_up_date,
-                   p.id AS patient_id, p.first_name, p.last_name, p.phone, p.blood_group,
-                   u.email
-            FROM appointments a
-            JOIN patients p ON a.patient_id = p.id
-            JOIN users u ON p.id = u.id
-            WHERE a.doctor_id = ?
-            ORDER BY a.appointment_date DESC, a.id DESC
-        `, [req.params.id]);
-        res.json(rows);
+        const { page, limit } = req.query;
+        const offset = (page - 1) * limit;
+
+        const [[{ total }]] = await db.query(
+            'SELECT COUNT(*) AS total FROM appointments WHERE doctor_id = ?',
+            [req.params.id]
+        );
+
+        const [rows] = await db.query(
+            `SELECT a.id AS appointment_id, a.appointment_date, a.time_slot, a.symptoms, a.status,
+                    a.diagnosis, a.notes, a.prescription, a.follow_up_date,
+                    p.id AS patient_id, p.first_name, p.last_name, p.phone, p.blood_group,
+                    u.email
+             FROM appointments a
+             JOIN patients p ON a.patient_id = p.id
+             JOIN users u ON p.id = u.id
+             WHERE a.doctor_id = ?
+             ORDER BY a.appointment_date DESC, a.id DESC
+             LIMIT ? OFFSET ?`,
+            [req.params.id, limit, offset]
+        );
+
+        res.json({
+            data: rows,
+            meta: {
+                total,
+                page,
+                limit,
+                total_pages: Math.ceil(total / limit)
+            }
+        });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Server error' });

--- a/backend/src/services/reminderService.js
+++ b/backend/src/services/reminderService.js
@@ -36,8 +36,9 @@ class ReminderService {
             JOIN patients p ON a.patient_id = p.id
             JOIN users u ON p.id = u.id
             JOIN doctors d ON a.doctor_id = d.id
-            WHERE a.appointment_date = ? AND a.status = 'CONFIRMED'
+            WHERE a.appointment_date = ? AND a.status = 'confirmed'
         `;
+        // BUG-005: was 'CONFIRMED' — statuses are stored lowercase at booking time
 
         const [appointments] = await db.query(query, [tomorrowStr]);
         
@@ -62,8 +63,9 @@ class ReminderService {
             JOIN patients p ON a.patient_id = p.id
             JOIN users u ON p.id = u.id
             JOIN doctors d ON a.doctor_id = d.id
-            WHERE a.appointment_date = ? AND a.status = 'CONFIRMED'
+            WHERE a.appointment_date = ? AND a.status = 'confirmed'
         `;
+        // BUG-005: was 'CONFIRMED' — statuses are stored lowercase at booking time
 
         const [appointments] = await db.query(query, [today]);
 


### PR DESCRIPTION
…ormalization

DB-003: Paginate GET /api/admin/appointments
- Added appointmentsQuerySchema (page, limit ≤100, status filter, date filter)
- Replaced unbounded full-table dump with COUNT + LIMIT/OFFSET query pair
- Returns { data, meta: { total, page, limit, total_pages } } envelope
- Status filter uses LOWER() to stay case-insensitive at the query level
- Swagger docs updated to reflect new query parameters

DB-007: Narrow SELECT * on doctor list endpoint
- GET /api/doctors now selects explicit columns via DOCTOR_LIST_COLUMNS constant, excluding the availability JSON blob (can be kilobytes per row)
- GET /api/doctors/:id retains availability for the booking UI slot picker

DB-005: Paginate GET /api/doctors/:id/patients
- Added patientsQuerySchema (page, limit ≤100, default 50)
- Now returns { data, meta } envelope with total_pages
- Prevents unbounded row dumps for high-volume doctors

BUG-005/008: Normalize appointment status casing to lowercase
- admin.js stats query: 4× UPPER 'CONFIRMED/COMPLETED/PENDING/CANCELLED' → LOWER(status) = 'confirmed/completed/pending/cancelled' (fixes silent zero counts in admin dashboard stats)
- appointments.js cancel guard: mixed 5-element array → String(appt.status).toLowerCase() against 3-element lowercase array
- reminderService.js: 2× 'CONFIRMED' → 'confirmed' (fixes reminders never firing on case-sensitive MySQL)
- reminderJobs.js: 2× 'CONFIRMED' → 'confirmed' (same fix for morning + proximity cron jobs)