### PR TITLE
docs: add frontend authentication documentation

### DIFF
--- a/docs/frontend-auth.md
+++ b/docs/frontend-auth.md
@@ -1,0 +1,22 @@
+# Frontend Authentication Documentation
+
+## Overview
+This document outlines how authentication is implemented on the frontend of the Patient Appointment Scheduling System.
+
+## Google Authentication Integration
+The frontend utilizes the `@react-oauth/google` library to seamlessly integrate Google Sign-In for patients. 
+
+### Prerequisites
+1. Ensure `VITE_GOOGLE_CLIENT_ID` is set in the Vercel Environment Variables.
+2. The Vercel URL must be added to the Authorized JavaScript origins in the Google Cloud Console.
+
+### Flow
+1. User clicks the "Sign in with Google" button.
+2. The `GoogleLogin` component handles the OAuth popup.
+3. Upon success, a Google ID token is returned.
+4. The token is sent to the backend (`/api/auth/google`) for verification.
+5. The backend validates the token, determines the user's role (auto-registering Patients if they don't exist), and issues a standard JWT.
+6. The frontend saves the JWT and redirects the user to their respective dashboard.
+
+### Fallbacks
+If the `VITE_GOOGLE_CLIENT_ID` is missing, the frontend will automatically hide the Google Login button and fallback strictly to email/password authentication to prevent React crashes.

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -163,23 +163,27 @@ const Login = () => {
                             </button>
                         </form>
 
-                        <div className="mt-6 flex items-center justify-center space-x-4">
-                            <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
-                            <span className="text-xs text-[var(--text-base)]/50 font-medium">OR</span>
-                            <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
-                        </div>
+                        {import.meta.env.VITE_GOOGLE_CLIENT_ID && (
+                            <>
+                                <div className="mt-6 flex items-center justify-center space-x-4">
+                                    <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
+                                    <span className="text-xs text-[var(--text-base)]/50 font-medium">OR</span>
+                                    <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
+                                </div>
 
-                        <div className="mt-6 flex justify-center w-full">
-                            <GoogleLogin
-                                onSuccess={handleGoogleSuccess}
-                                onError={() => {
-                                    setError('Google login was unsuccessful or canceled.');
-                                }}
-                                useOneTap
-                                theme="filled_blue"
-                                shape="pill"
-                            />
-                        </div>
+                                <div className="mt-6 flex justify-center w-full">
+                                    <GoogleLogin
+                                        onSuccess={handleGoogleSuccess}
+                                        onError={() => {
+                                            setError('Google login was unsuccessful or canceled.');
+                                        }}
+                                        useOneTap
+                                        theme="filled_blue"
+                                        shape="pill"
+                                    />
+                                </div>
+                            </>
+                        )}
 
                         <div className="mt-10 pt-8 border-t border-[var(--border-base)]/30 text-center">
                             <p className="text-sm text-[var(--text-base)]/60">

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -131,24 +131,28 @@ const Register = () => {
 
                         {step === 1 ? (
                             <form onSubmit={handleStep1} className="space-y-6">
-                                <div className="mb-6 flex justify-center w-full">
-                                    <GoogleLogin
-                                        onSuccess={handleGoogleSuccess}
-                                        onError={() => {
-                                            setError('Google signup was unsuccessful or canceled.');
-                                        }}
-                                        text="signup_with"
-                                        useOneTap
-                                        theme="filled_blue"
-                                        shape="pill"
-                                    />
-                                </div>
-                                
-                                <div className="mb-6 flex items-center justify-center space-x-4">
-                                    <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
-                                    <span className="text-xs text-[var(--text-base)]/50 font-medium">OR</span>
-                                    <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
-                                </div>
+                                {import.meta.env.VITE_GOOGLE_CLIENT_ID && (
+                                    <>
+                                        <div className="mb-6 flex justify-center w-full">
+                                            <GoogleLogin
+                                                onSuccess={handleGoogleSuccess}
+                                                onError={() => {
+                                                    setError('Google signup was unsuccessful or canceled.');
+                                                }}
+                                                text="signup_with"
+                                                useOneTap
+                                                theme="filled_blue"
+                                                shape="pill"
+                                            />
+                                        </div>
+                                        
+                                        <div className="mb-6 flex items-center justify-center space-x-4">
+                                            <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
+                                            <span className="text-xs text-[var(--text-base)]/50 font-medium">OR</span>
+                                            <div className="h-px bg-[var(--border-base)]/30 w-full flex-1"></div>
+                                        </div>
+                                    </>
+                                )}
 
                                 <h3 className="text-xl font-bold text-[var(--text-base)] mb-6">Basic Information</h3>
                                 <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
Adding documentation to trigger Vercel rebuild for frontend testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added frontend authentication guide covering Google Sign-In integration, environment configuration, and authentication workflows.

* **Bug Fixes**
  * Google Sign-In now conditionally displays in Login and Register pages based on configuration, gracefully falling back to email/password authentication when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->