### PR TITLE
feat(backend): add graceful shutdown handler for SIGTERM/SIGINT

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -448,11 +448,50 @@ app.use(errorHandler);
 
 const PORT = process.env.PORT || 7860;
 if (process.env.NODE_ENV !== 'test') {
-    app.listen(PORT, () => {
+    const server = app.listen(PORT, () => {
         logger.info(`Server listening on port ${PORT} in ${process.env.NODE_ENV || 'development'} mode`);
         // Initialize Background Jobs
         initCronJobs();
     });
+
+    // ── Graceful Shutdown ──────────────────────────────────────────────────────
+    // On SIGTERM (container orchestrators) / SIGINT (Ctrl-C), stop accepting new
+    // connections, drain the MySQL pool, and exit cleanly so in-flight requests
+    // are not dropped on deploys / restarts.
+    let shuttingDown = false;
+    async function shutdown(signal) {
+        if (shuttingDown) return;
+        shuttingDown = true;
+        logger.info(`Received ${signal} — shutting down gracefully`);
+
+        // Force-exit if cleanup takes longer than the timeout
+        const forceExit = setTimeout(() => {
+            logger.error('Graceful shutdown timed out — forcing exit');
+            process.exit(1);
+        }, 10000);
+        forceExit.unref();
+
+        server.close((err) => {
+            if (err) logger.error('Error closing HTTP server:', err);
+
+            try {
+                const db = require('./config/db');
+                db.end().then(() => {
+                    logger.info('Database pool closed');
+                    process.exit(err ? 1 : 0);
+                }).catch((dbErr) => {
+                    logger.error('Error closing database pool:', dbErr);
+                    process.exit(1);
+                });
+            } catch {
+                // DB module not loaded — exit once HTTP server is closed
+                process.exit(err ? 1 : 0);
+            }
+        });
+    }
+
+    process.on('SIGTERM', () => shutdown('SIGTERM'));
+    process.on('SIGINT', () => shutdown('SIGINT'));
 }
 
 module.exports = app;


### PR DESCRIPTION
## Summary
- Capture the `server` reference from `app.listen()`
- On `SIGTERM` (container orchestrators like k8s/ECS) / `SIGINT` (Ctrl-C): stop accepting new connections, drain the MySQL connection pool, then exit cleanly
- 10-second force-kill timeout prevents hung shutdowns if cleanup stalls

## Why this matters
Without a graceful shutdown handler, container restarts and deploys **drop in-flight HTTP requests** and leave DB connections lingering until they time out. Orchestrators send `SIGTERM` with a grace period expecting the app to drain — this handler honors that contract.

## Verification
Smoke-tested the full lifecycle locally:
```
✓ Server boots, health check returns 200
✓ SIGTERM received → "shutting down gracefully" logged
✓ HTTP server closed, DB pool drained ("Database pool closed")
✓ Process exits cleanly
```
- ✅ 174/174 backend tests pass
- Pre-commit hooks pass