### PR TITLE
feat(security): configure Helmet Content Security Policy (CSP)

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -85,8 +85,11 @@ const swaggerOptions = {
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
-// Security Middleware
-app.use(helmet());
+// Security Middleware — baseline Helmet (CSP configured after origins are resolved below)
+app.use(helmet({
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+    contentSecurityPolicy: false,   // set via a dedicated middleware below once origins are known
+}));
 
 // Strict CORS
 function normalizeOrigin(value) {
@@ -137,6 +140,25 @@ const corsOptions = {
     credentials: true
 };
 app.use(cors(corsOptions));
+
+// ── Content Security Policy ───────────────────────────────────────────────────
+// Applied AFTER the CORS whitelist is built so connect-src stays in sync with the
+// allowed origins. The API serves JSON to the SPA; scripts/styles are loaded by
+// the frontend bundle, not here, so directives are intentionally restrictive.
+app.use(helmet.contentSecurityPolicy({
+    useDefaults: true,
+    directives: {
+        defaultSrc: ["'self'"],
+        // The SPA connects to this API plus any whitelisted deployment origins
+        connectSrc: ["'self'", ...whitelist],
+        imgSrc: ["'self'", 'data:', 'blob:'],
+        fontSrc: ["'self'", 'data:'],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        baseUri: ["'self'"],
+        formAction: ["'self'"],
+    },
+}));
 
 // ── Global Rate Limiter ────────────────────────────────────────────────────────
 // Reads window/max from env so production can be tuned without code changes.


### PR DESCRIPTION
## Summary
Replaces the bare `app.use(helmet())` (no CSP) with an explicit, baseline Content Security Policy.

## Changes
- **`default-src 'self'`** — strict default
- **`connect-src` derives from the CORS whitelist** — so the SPA's API origins stay in sync with `ALLOWED_ORIGINS`/`APP_URL`/`FRONTEND_URL` env vars automatically
- **`object-src 'none'`**, **`frame-ancestors 'none'`** — blocks plugins & clickjacking
- **`crossOriginResourcePolicy: cross-origin`** — allows API resources to be consumed cross-origin
- Restrictive `img-src`/`font-src`/`base-uri`/`form-action` directives

## Why this matters
A healthcare SPA with no CSP is exposed to injected scripts (XSS). Combined with the existing localStorage JWT, a CSP is the most effective defense-in-depth against token theft. This is the first layer of the JWT-hardening work.

## Verification
Smoke-tested live headers on `/api/health`:
```
Content-Security-Policy: default-src 'self';connect-src 'self' http://localhost:5173 ...;object-src 'none';frame-ancestors 'none'...
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Content-Type-Options: nosniff
```
- ✅ 174/174 backend tests pass
- Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened browser security policies to better protect the app.
  * Added a stricter content security policy to limit where content can load from, while still allowing approved frontend and deployment connections.
  * Reduced exposure to unsafe embeds and framing, and tightened rules for images, fonts, and form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->