### PR TITLE
fix(frontend): remove hardcoded production API URL and Stripe sample key

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,9 +1,14 @@
 # Copy this file to .env and update the values for your environment.
 # VITE_ prefix is required for Vite to expose the variable to client code.
 
-# Backend API base URL (no trailing slash)
-# Local dev: http://localhost:7860
-# Production (Hugging Face Space): https://archittmittal-backend-patientappointment.hf.space
+# Backend API base URL (no trailing slash).
+# REQUIRED in production builds — the app no longer falls back to a hardcoded URL.
+# Local dev:  http://localhost:7860
+# Production: https://your-api-host.example.com
 VITE_API_URL=http://localhost:7860
 
-VITE_STRIPE_PUBLIC_KEY=pk_test_TYooMQauvdEDq54NiTphI7jx
+# Optional: override the port used for local dev detection (defaults to 7860)
+# VITE_LOCAL_PORT=7860
+
+# Stripe publishable key (safe to expose; this is your OWN key, not the sample below)
+VITE_STRIPE_PUBLIC_KEY=pk_test_YOUR_STRIPE_PUBLISHABLE_KEY

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,15 +1,21 @@
 // Central API base URL.
 // Priority: Localhost/127.0.0.1 override (Highest priority, respects VITE_LOCAL_PORT fallback to 7860)
-//           → VITE_API_URL env var if not local
-//           → Production Hugging Face Space fallback
-const PRODUCTION_API = 'https://archittmittal-backend-patientappointment.hf.space';
-
+//           → VITE_API_URL env var (REQUIRED in production)
+//
+// In production VITE_API_URL must be set at build time (see .env / deployment config).
+// We deliberately do NOT bake in a hardcoded deployment URL — that couples the
+// build to a single host and silently masks a missing env var.
 const localPort = import.meta.env.VITE_LOCAL_PORT || '7860';
 const isLocal = typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
 
+if (!isLocal && !import.meta.env.VITE_API_URL) {
+     
+    console.error('[api] VITE_API_URL is not set — production build will fail to reach the API. Set it in your deployment environment.');
+}
+
 export const API = isLocal
     ? `http://localhost:${localPort}`
-    : (import.meta.env.VITE_API_URL || PRODUCTION_API);
+    : (import.meta.env.VITE_API_URL || '');
 
 export const API_URL = `${API}/api`;
 


### PR DESCRIPTION
## Summary
Combines Steps 5 & 6 from the production-readiness plan (same files, tightly related).

### 1. Remove hardcoded production API URL (`frontend/src/config/api.js`)
- Deleted the hardcoded `PRODUCTION_API = 'https://archittmittal-...hf.space'` constant
- Production builds now **require** `VITE_API_URL` to be set at build time
- Emits a loud `console.error` if `VITE_API_URL` is missing in production — fails loud, not silent

### 2. Replace Stripe sample key (`frontend/.env.example`)
- Changed the well-known Stripe documentation sample key (`pk_test_TYooMQauvdEDq54NiTphI7jx`) to a placeholder
- Documented `VITE_LOCAL_PORT` override

## Why this matters
- **Decoupling:** the build is no longer welded to a single free-tier Hugging Face Space host. Migrating/deploying elsewhere just needs a new env var.
- **Hygiene:** the sample Stripe key signaled copy-paste and could confuse Stripe's tooling.

## Verification
- ✅ Frontend build clean
- ✅ 31/31 frontend tests pass