### PR TITLE
[PR #2] feat: Restrict Analytics Access & Standardize Authorization

### DIFF
--- a/backend/src/routes/appointments.js
+++ b/backend/src/routes/appointments.js
@@ -774,9 +774,13 @@ router.patch('/:id/cancel', authenticate, async (req, res) => {
 });
 
 // GET /api/appointments/analytics/doctor/:doctorId — get prediction analytics for a doctor
-router.get('/analytics/doctor/:doctorId', authenticate, async (req, res) => {
+router.get('/analytics/doctor/:doctorId', authenticate, requireRole(['DOCTOR', 'ADMIN']), async (req, res) => {
     try {
         const doctorId = req.params.doctorId;
+
+        if (req.user.role === 'DOCTOR' && parseInt(req.user.id) !== parseInt(doctorId)) {
+            return res.status(403).json({ message: 'Access denied: You can only view your own analytics' });
+        }
 
         // Get doctor's average times
         const [avgTimesRows] = await db.query(
@@ -848,7 +852,7 @@ router.get('/analytics/doctor/:doctorId', authenticate, async (req, res) => {
 });
 
 // GET /api/appointments/analytics/symptoms — get symptom complexity data
-router.get('/analytics/symptoms', authenticate, async (req, res) => {
+router.get('/analytics/symptoms', authenticate, requireRole(['DOCTOR', 'ADMIN']), async (req, res) => {
     try {
         const [symptoms] = await db.query(
             `SELECT keyword, complexity_score, avg_extra_mins FROM symptom_complexity ORDER BY complexity_score DESC`
@@ -1055,9 +1059,13 @@ router.get('/:id/smart-arrival', authenticate, async (req, res) => {
 });
 
 // GET /api/appointments/doctor/:doctorId/smart-arrivals - Get all smart arrivals for a doctor today
-router.get('/doctor/:doctorId/smart-arrivals', authenticate, async (req, res) => {
+router.get('/doctor/:doctorId/smart-arrivals', authenticate, requireRole(['DOCTOR', 'ADMIN']), async (req, res) => {
     try {
-        const results = await smartArrivalService.getBatchSmartArrivals(parseInt(req.params.doctorId));
+        const doctorId = parseInt(req.params.doctorId);
+        if (req.user.role === 'DOCTOR' && parseInt(req.user.id) !== doctorId) {
+            return res.status(403).json({ message: 'Access denied: You can only view your own smart arrivals' });
+        }
+        const results = await smartArrivalService.getBatchSmartArrivals(doctorId);
         res.json(results);
     } catch (error) {
         logger.error('Batch smart arrivals error:', error);

--- a/backend/src/routes/doctors.js
+++ b/backend/src/routes/doctors.js
@@ -132,7 +132,7 @@ router.get('/:id', async (req, res) => {
 // PATCH /api/doctors/:id — update doctor profile (photo, bio, specialty, etc.)
 router.patch('/:id', authenticate, requireRole('DOCTOR'), validateRequest(doctorProfileSchema), async (req, res) => {
     // Only the doctor themselves can update their profile
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -183,7 +183,7 @@ router.get('/:id/slot-counts', async (req, res) => {
 // PATCH /api/doctors/:id/availability — update weekly schedule
 router.patch('/:id/availability', authenticate, requireRole('DOCTOR'), validateRequest(availabilitySchema), async (req, res) => {
     // Only the doctor themselves can update their availability
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -233,7 +233,7 @@ router.get('/:id/reviews', async (req, res) => {
 // DB-005: Paginated — default 50 per page to avoid unbounded dumps for high-volume doctors
 router.get('/:id/patients', authenticate, requireRole('DOCTOR'), validateRequest(patientsQuerySchema, 'query'), async (req, res) => {
     // Only the doctor themselves can view their patient list
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -277,7 +277,7 @@ router.get('/:id/patients', authenticate, requireRole('DOCTOR'), validateRequest
 // GET /api/doctors/:id/queue — today's live queue for this doctor
 router.get('/:id/queue', authenticate, requireRole('DOCTOR'), async (req, res) => {
     // Only the doctor themselves can view their queue
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -316,7 +316,7 @@ router.get('/:id/blocked-dates', async (req, res) => {
 // POST /api/doctors/:id/blocked-dates — block a specific date
 router.post('/:id/blocked-dates', authenticate, requireRole('DOCTOR'), validateRequest(blockedDateSchema), async (req, res) => {
     // Only the doctor themselves can block dates
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -339,7 +339,7 @@ router.post('/:id/blocked-dates', authenticate, requireRole('DOCTOR'), validateR
 // DELETE /api/doctors/:id/blocked-dates/:dateId — unblock a date
 router.delete('/:id/blocked-dates/:dateId', authenticate, requireRole('DOCTOR'), async (req, res) => {
     // Only the doctor themselves can unblock dates
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {

--- a/backend/src/routes/patients.js
+++ b/backend/src/routes/patients.js
@@ -79,7 +79,7 @@ const trendsQuerySchema = Joi.object({
 // Get a patient's simple profile
 router.get('/:id', authenticate, async (req, res) => {
     // Check if the user is authorized to view this profile
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -97,7 +97,7 @@ router.get('/:id', authenticate, async (req, res) => {
 // PATCH /api/patients/:id — update editable profile fields
 router.patch('/:id', authenticate, validateRequest(patientProfileSchema), async (req, res) => {
     // Only the patient themselves can update their profile
-    if (req.user.id != req.params.id) {
+    if (parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -123,7 +123,7 @@ router.patch('/:id', authenticate, validateRequest(patientProfileSchema), async 
 // Get a patient's appointments — supports ?type=upcoming|past (default: upcoming)
 router.get('/:id/appointments', authenticate, validateRequest(appointmentsQuerySchema, 'query'), async (req, res) => {
     // Check authorization: doctors/admins or the patient themselves
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -167,7 +167,7 @@ const logger = require('../config/logger');
 
 // Issue #94: Get patient prescriptions
 router.get('/:id/prescriptions', authenticate, verifyConsent, async (req, res) => {
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -181,7 +181,7 @@ router.get('/:id/prescriptions', authenticate, verifyConsent, async (req, res) =
 
 // Issue #95: Get patient vitals history
 router.get('/:id/vitals', authenticate, verifyConsent, async (req, res) => {
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -206,7 +206,7 @@ const vitalsSchema = Joi.object({
 // Issue #95: Log new vitals (now with abnormal alerts)
 router.post('/:id/vitals', authenticate, verifyConsent, validateRequest(vitalsSchema), async (req, res) => {
     // Both patients (self-logging) and doctors can log vitals
-    if (req.user.role !== 'DOCTOR' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -220,7 +220,7 @@ router.post('/:id/vitals', authenticate, verifyConsent, validateRequest(vitalsSc
 
 // Issue #144: Get vitals trends and analytics
 router.get('/:id/vitals/trends', authenticate, verifyConsent, validateRequest(trendsQuerySchema, 'query'), async (req, res) => {
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -235,7 +235,7 @@ router.get('/:id/vitals/trends', authenticate, verifyConsent, validateRequest(tr
 
 // Issue #110: Export patient vitals as CSV
 router.get('/:id/vitals/export', authenticate, verifyConsent, async (req, res) => {
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -248,7 +248,7 @@ router.get('/:id/vitals/export', authenticate, verifyConsent, async (req, res) =
 
 // Issue #144: Get full prescription history (including inactive)
 router.get('/:id/prescriptions/history', authenticate, verifyConsent, async (req, res) => {
-    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'DOCTOR' && req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
     try {
@@ -332,7 +332,7 @@ const consentSchema = Joi.object({
 // POST /api/patients/:id/consent — grant/revoke consent for a doctor
 router.post('/:id/consent', authenticate, validateRequest(consentSchema), async (req, res) => {
     // Only the patient themselves or an ADMIN can manage consent
-    if (req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
 
@@ -372,7 +372,7 @@ const abhaLinkSchema = Joi.object({
 // POST /api/patients/:id/abha — link/update ABHA details for an existing patient
 router.post('/:id/abha', authenticate, validateRequest(abhaLinkSchema), async (req, res) => {
     // Only the patient themselves or an ADMIN can manage ABHA linking
-    if (req.user.role !== 'ADMIN' && req.user.id != req.params.id) {
+    if (req.user.role !== 'ADMIN' && parseInt(req.user.id, 10) !== parseInt(req.params.id, 10)) {
         return res.status(403).json({ message: 'Access denied' });
     }
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -84,7 +84,9 @@ const swaggerOptions = {
 };
 
 const swaggerSpec = swaggerJsdoc(swaggerOptions);
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+if (process.env.NODE_ENV !== 'production') {
+    app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+}
 
 // Security Middleware — baseline Helmet (CSP configured after origins are resolved below)
 app.use(helmet({
@@ -211,6 +213,7 @@ if (process.env.DISABLE_RATE_LIMITER !== 'true') {
     app.use('/api/', globalLimiter);
     app.use('/api/auth/login', authLimiter);
     app.use('/api/auth/register', authLimiter);
+    app.use('/api/auth/forgot-password', authLimiter);
 }
 
 // Routes


### PR DESCRIPTION
Implements requireRole and ownership validation on analytics/smart-arrival endpoints, adds forgot-password rate limiter, gates Swagger in production, and standardizes 16 loose equality checks. Closes #292