### PR TITLE
[PR #3] fix: Pin JWT Algorithms & Hash One-Time Passwords (OTPs)

### DIFF
--- a/backend/src/middleware/authenticate.js
+++ b/backend/src/middleware/authenticate.js
@@ -64,7 +64,7 @@ function authenticateSse(req, res, next) {
 
 function verifyToken(token, req, res, next) {
     try {
-        req.user = jwt.verify(token, jwtSecret);
+        req.user = jwt.verify(token, jwtSecret, { algorithms: ['HS256'] });
         return next();
     } catch {
         return res.status(401).json({ message: 'Invalid or expired token' });

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -135,11 +135,12 @@ class AuthService {
                     // instead of the predictable Math.random()
                     const otp = crypto.randomInt(100000, 1000000).toString();
                     const expiry = new Date(Date.now() + 10 * 60 * 1000); // 10 mins
+                    const hashedOtp = await bcrypt.hash(otp, bcryptRounds);
 
                     // Reset failed attempts on new OTP generation
                     await db.query(
                         'UPDATE users SET otp_code = ?, otp_expiry = ?, failed_otp_attempts = 0 WHERE email = ?',
-                        [otp, expiry, email]
+                        [hashedOtp, expiry, email]
                     );
 
                     await sendOTP(email, otp);
@@ -166,11 +167,16 @@ class AuthService {
         }
 
         const [users] = await db.query(
-            'SELECT * FROM users WHERE email = ? AND otp_code = ? AND otp_expiry > NOW()',
-            [email, otp]
+            'SELECT id, otp_code, otp_expiry FROM users WHERE email = ?',
+            [email]
         );
 
-        if (users.length === 0) {
+        let otpValid = false;
+        if (users.length > 0 && users[0].otp_code && users[0].otp_expiry && new Date(users[0].otp_expiry) > new Date()) {
+            otpValid = await bcrypt.compare(otp, users[0].otp_code);
+        }
+
+        if (!otpValid) {
             // [SEC-007] Increment failed attempt counter and lock after 5 failures
             const MAX_OTP_ATTEMPTS = 5;
             const LOCKOUT_MINUTES = 15;

--- a/backend/src/services/sessionService.js
+++ b/backend/src/services/sessionService.js
@@ -1,14 +1,14 @@
 const jwt = require('jsonwebtoken');
-const { jwtSecret } = require('../middleware/authenticate');
+const { jwtSecret, jwtExpiresIn } = require('../config/auth');
 
 class SessionService {
     /**
      * Generate a new JWT token for a user
      * @param {Object} user User object containing id, email, role
-     * @param {string} expiresIn Token expiry time (default 8h)
+     * @param {string} expiresIn Token expiry time (default config-driven)
      * @returns {string} JWT token
      */
-    generateToken(user, expiresIn = '8h') {
+    generateToken(user, expiresIn = jwtExpiresIn) {
         return jwt.sign(
             { id: user.id, email: user.email, role: user.role },
             jwtSecret,
@@ -23,7 +23,7 @@ class SessionService {
      */
     verifyToken(token) {
         try {
-            return jwt.verify(token, jwtSecret);
+            return jwt.verify(token, jwtSecret, { algorithms: ['HS256'] });
         } catch (error) {
             return null;
         }


### PR DESCRIPTION
Pins jwt.verify signature algorithm to HS256, encrypts OTP codes using bcrypt before database storage, and resolves circular dependency in sessionService. Closes #293