### PR TITLE
[PR #4] feat: Resolve Appointment Booking Status Enums & Capacity Schema

### DIFF
--- a/backend/database/apply_migrations.js
+++ b/backend/database/apply_migrations.js
@@ -17,7 +17,8 @@ async function applyMigrations() {
         'migrations/migration_sprint12_consent_logs.sql',
         'migrations/migration_sprint13_abha_support.sql',
         'migration_advanced_portal.sql',
-        'migration_issue144_medical_data.sql'
+        'migration_issue144_medical_data.sql',
+        'migrations/migration_sprint14_capacity_booking.sql'
     ];
 
     console.log('--- Starting Migration Verification ---');

--- a/backend/database/migrations/migration_sprint14_capacity_booking.sql
+++ b/backend/database/migrations/migration_sprint14_capacity_booking.sql
@@ -1,0 +1,4 @@
+-- Migration: Drop unique_booking constraint to allow multi-patient slots
+-- Phase 2 — PR #4
+ALTER TABLE appointments DROP INDEX unique_booking;
+CREATE INDEX idx_appointments_doctor_date_slot ON appointments(doctor_id, appointment_date, time_slot);

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS appointments (
     predicted_duration_mins INT DEFAULT 15,
     is_follow_up BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE KEY unique_booking (doctor_id, appointment_date, time_slot),
+    INDEX idx_appointments_doctor_date_slot (doctor_id, appointment_date, time_slot),
     INDEX idx_appointments_doctor_date (doctor_id, appointment_date),
     INDEX idx_appointments_patient_date (patient_id, appointment_date),
     INDEX idx_appointments_status (status),

--- a/backend/src/routes/appointments.js
+++ b/backend/src/routes/appointments.js
@@ -495,7 +495,7 @@ router.patch('/queue/:queueId/status', authenticate, requireRole('DOCTOR'), vali
         // 2. Handle status-specific logic
         if (status === 'IN_PROGRESS') {
             await conn.query(
-                "UPDATE appointments a JOIN live_queue lq ON a.id = lq.appointment_id SET a.consultation_start = NOW(), a.status = 'in_progress' WHERE lq.id = ?",
+                "UPDATE appointments a JOIN live_queue lq ON a.id = lq.appointment_id SET a.consultation_start = NOW(), a.status = 'IN_PROGRESS' WHERE lq.id = ?",
                 [req.params.queueId]
             );
 


### PR DESCRIPTION
Standardizes queue appointment status writes to uppercase (IN_PROGRESS), drops the database level UNIQUE constraint unique_booking on doctor/date/time_slot, and updates schema.sql to support multiple bookings per time slot (up to 15 patients per slot). Closes #294