### PR TITLE
[PR #12] feat: JWT Refresh Tokens & Session Revocation

### DIFF
--- a/backend/database/apply_migrations.js
+++ b/backend/database/apply_migrations.js
@@ -18,7 +18,8 @@ async function applyMigrations() {
         'migrations/migration_sprint13_abha_support.sql',
         'migration_advanced_portal.sql',
         'migration_issue144_medical_data.sql',
-        'migrations/migration_sprint14_capacity_booking.sql'
+        'migrations/migration_sprint14_capacity_booking.sql',
+        'migrations/migration_sprint15_refresh_tokens.sql'
     ];
 
     console.log('--- Starting Migration Verification ---');

--- a/backend/database/migrations/migration_sprint15_refresh_tokens.sql
+++ b/backend/database/migrations/migration_sprint15_refresh_tokens.sql
@@ -1,0 +1,10 @@
+-- Migration for Issue #12: JWT Refresh Tokens & Session Revocation
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_refresh_token (token)
+);

--- a/backend/src/config/auth.js
+++ b/backend/src/config/auth.js
@@ -78,7 +78,7 @@ const authConfig = {
      * Accepts any value accepted by the `jsonwebtoken` `expiresIn` option
      * (e.g. "8h", "1d", "7d").
      */
-    jwtExpiresIn: process.env.JWT_EXPIRES_IN || '8h',
+    jwtExpiresIn: process.env.JWT_EXPIRES_IN || '15m',
 
     /**
      * bcrypt work factor (cost). Higher = slower hashing but more secure.

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -58,6 +58,28 @@ class AuthController {
             res.status(error.status || 500).json({ message: error.message || 'Server error' });
         }
     }
+
+    async refresh(req, res) {
+        try {
+            const { refreshToken } = req.body;
+            const result = await authService.refreshSession(refreshToken);
+            res.json(result);
+        } catch (error) {
+            logger.error('[Token Refresh Error]', error);
+            res.status(error.status || 500).json({ message: error.message || 'Server error' });
+        }
+    }
+
+    async revoke(req, res) {
+        try {
+            const { refreshToken } = req.body;
+            const result = await authService.revokeSession(refreshToken);
+            res.json(result);
+        } catch (error) {
+            logger.error('[Token Revocation Error]', error);
+            res.status(error.status || 500).json({ message: error.message || 'Server error' });
+        }
+    }
 }
 
 module.exports = new AuthController();

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -77,6 +77,24 @@ router.post('/reset-password', authController.resetPassword);
  */
 router.post('/google', validateRequest(Joi.object({ token: Joi.string().min(1).required() })), authController.googleLogin);
 
+/**
+ * @swagger
+ * /api/auth/refresh:
+ *   post:
+ *     summary: Rotate access and refresh tokens
+ *     tags: [Auth]
+ */
+router.post('/refresh', validateRequest(Joi.object({ refreshToken: Joi.string().required() })), authController.refresh);
+
+/**
+ * @swagger
+ * /api/auth/revoke:
+ *   post:
+ *     summary: Revoke refresh token (logout)
+ *     tags: [Auth]
+ */
+router.post('/revoke', validateRequest(Joi.object({ refreshToken: Joi.string().required() })), authController.revoke);
+
 const abhaService = require('../services/abhaService');
 const logger = require('../config/logger');
 

--- a/backend/src/services/authService.js
+++ b/backend/src/services/authService.js
@@ -43,6 +43,7 @@ class AuthService {
         }
 
         const token = sessionService.generateToken(user);
+        const refreshToken = await sessionService.generateRefreshToken(user.id);
 
         return {
             id: user.id,
@@ -50,7 +51,8 @@ class AuthService {
             role: user.role,
             first_name: firstName,
             last_name: lastName,
-            token
+            token,
+            refreshToken
         };
     }
 
@@ -96,8 +98,9 @@ class AuthService {
             await conn.commit();
 
             const token = sessionService.generateToken({ id: newId, email, role: 'PATIENT' });
+            const refreshToken = await sessionService.generateRefreshToken(newId);
 
-            return { id: newId, email, role: 'PATIENT', first_name, last_name, token, abha_id: abha_id || null, abha_number: abha_number || null };
+            return { id: newId, email, role: 'PATIENT', first_name, last_name, token, refreshToken, abha_id: abha_id || null, abha_number: abha_number || null };
         } catch (error) {
             await conn.rollback();
             if (error.code === 'ER_DUP_ENTRY') {
@@ -313,6 +316,7 @@ class AuthService {
         }
 
         const token = sessionService.generateToken(user);
+        const refreshToken = await sessionService.generateRefreshToken(user.id);
 
         return {
             id: user.id,
@@ -320,8 +324,82 @@ class AuthService {
             role: user.role,
             first_name: firstName,
             last_name: lastName,
-            token
+            token,
+            refreshToken
         };
+    }
+
+    /**
+     * Rotate access and refresh tokens using a valid refresh token
+     * @param {string} refreshToken Active refresh token
+     * @returns {Promise<Object>} New access and refresh token pair
+     */
+    async refreshSession(refreshToken) {
+        if (!refreshToken) {
+            const error = new Error('Refresh token is required');
+            error.status = 400;
+            throw error;
+        }
+
+        // Query database for refresh token
+        const [rows] = await db.query(
+            'SELECT * FROM refresh_tokens WHERE token = ?',
+            [refreshToken]
+        );
+
+        if (rows.length === 0) {
+            const error = new Error('Invalid or expired refresh token');
+            error.status = 401;
+            throw error;
+        }
+
+        const storedToken = rows[0];
+        
+        // Check expiry
+        if (new Date(storedToken.expires_at) < new Date()) {
+            await db.query('DELETE FROM refresh_tokens WHERE token = ?', [refreshToken]);
+            const error = new Error('Refresh token expired');
+            error.status = 401;
+            throw error;
+        }
+
+        // Fetch user details
+        const [users] = await db.query('SELECT * FROM users WHERE id = ?', [storedToken.user_id]);
+        if (users.length === 0) {
+            const error = new Error('User not found');
+            error.status = 401;
+            throw error;
+        }
+
+        const user = users[0];
+
+        // Generate new tokens (rotation)
+        const newAccessToken = sessionService.generateToken(user);
+        const newRefreshToken = await sessionService.generateRefreshToken(user.id);
+
+        // Delete the old refresh token (token rotation prevention)
+        await db.query('DELETE FROM refresh_tokens WHERE token = ?', [refreshToken]);
+
+        return {
+            token: newAccessToken,
+            refreshToken: newRefreshToken
+        };
+    }
+
+    /**
+     * Revoke a refresh token (logout)
+     * @param {string} refreshToken Active refresh token
+     * @returns {Promise<Object>} Status message
+     */
+    async revokeSession(refreshToken) {
+        if (!refreshToken) {
+            const error = new Error('Refresh token is required');
+            error.status = 400;
+            throw error;
+        }
+
+        await db.query('DELETE FROM refresh_tokens WHERE token = ?', [refreshToken]);
+        return { message: 'Token revoked successfully' };
     }
 }
 

--- a/backend/src/services/sessionService.js
+++ b/backend/src/services/sessionService.js
@@ -1,4 +1,6 @@
 const jwt = require('jsonwebtoken');
+const crypto = require('crypto');
+const db = require('../config/db');
 const { jwtSecret, jwtExpiresIn } = require('../config/auth');
 
 class SessionService {
@@ -27,6 +29,26 @@ class SessionService {
         } catch (error) {
             return null;
         }
+    }
+
+    /**
+     * Generate a new Refresh Token
+     * @param {number} userId User ID
+     * @returns {Promise<string>} Refresh token string
+     */
+    async generateRefreshToken(userId) {
+        const token = crypto.randomBytes(40).toString('hex');
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + 7); // expires in 7 days
+        
+        const expiresAtMysql = expiresAt.toISOString().slice(0, 19).replace('T', ' ');
+
+        await db.query(
+            'INSERT INTO refresh_tokens (user_id, token, expires_at) VALUES (?, ?, ?)',
+            [userId, token, expiresAtMysql]
+        );
+
+        return token;
     }
 }
 

--- a/backend/tests/session.test.js
+++ b/backend/tests/session.test.js
@@ -1,0 +1,171 @@
+const request = require('supertest');
+const app = require('../src/server');
+const db = require('../src/config/db');
+const jwt = require('jsonwebtoken');
+
+// Mock database module
+jest.mock('../src/config/db', () => {
+    const mockQuery = jest.fn();
+    return {
+        query: mockQuery,
+        getConnection: jest.fn()
+    };
+});
+
+describe('JWT Refresh Tokens & Session Revocation Tests (PR #12)', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        db.query.mockClear();
+    });
+
+    describe('Access Token Lifespan', () => {
+        it('should generate an access token with a 15-minute expiration (900 seconds) by default', async () => {
+            // Mock login behavior
+            const mockUser = {
+                id: 101,
+                email: 'patient@example.com',
+                password_hash: '$2a$10$abcdefghijklmnopqrstuv', // valid mock hash
+                role: 'PATIENT',
+                auth_provider: 'LOCAL'
+            };
+            const mockPatientProfile = { first_name: 'John', last_name: 'Doe' };
+
+            db.query.mockImplementation((sql, params) => {
+                const upperSql = sql.trim().toUpperCase();
+                if (upperSql.includes('SELECT * FROM USERS')) {
+                    return Promise.resolve([[mockUser], []]);
+                }
+                if (upperSql.includes('SELECT FIRST_NAME, LAST_NAME FROM PATIENTS')) {
+                    return Promise.resolve([[mockPatientProfile], []]);
+                }
+                if (upperSql.includes('INSERT INTO REFRESH_TOKENS')) {
+                    return Promise.resolve([{ affectedRows: 1, insertId: 1 }, []]);
+                }
+                return Promise.resolve([[], []]);
+            });
+
+            // Mock bcrypt.compare to succeed
+            const bcrypt = require('bcryptjs');
+            jest.spyOn(bcrypt, 'compare').mockResolvedValue(true);
+
+            const res = await request(app)
+                .post('/api/auth/login')
+                .send({ email: 'patient@example.com', password: 'Password123' });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toHaveProperty('token');
+            expect(res.body).toHaveProperty('refreshToken');
+
+            const decoded = jwt.decode(res.body.token);
+            expect(decoded).toHaveProperty('exp');
+            expect(decoded).toHaveProperty('iat');
+            
+            // Difference in seconds should be 15 mins (900s)
+            const duration = decoded.exp - decoded.iat;
+            expect(duration).toBe(900);
+        });
+    });
+
+    describe('Token Rotation (POST /api/auth/refresh)', () => {
+        it('should issue a new token pair and delete the old refresh token', async () => {
+            const mockRefreshToken = 'old_refresh_token_string';
+            const mockStoredToken = {
+                id: 1,
+                user_id: 101,
+                token: mockRefreshToken,
+                expires_at: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toISOString() // 7 days in future
+            };
+            const mockUser = { id: 101, email: 'patient@example.com', role: 'PATIENT' };
+
+            db.query.mockImplementation((sql, params) => {
+                const upperSql = sql.trim().toUpperCase();
+                if (upperSql.includes('SELECT * FROM REFRESH_TOKENS WHERE TOKEN = ?')) {
+                    return Promise.resolve([[mockStoredToken], []]);
+                }
+                if (upperSql.includes('SELECT * FROM USERS WHERE ID = ?')) {
+                    return Promise.resolve([[mockUser], []]);
+                }
+                if (upperSql.includes('DELETE FROM REFRESH_TOKENS WHERE TOKEN = ?')) {
+                    return Promise.resolve([{ affectedRows: 1 }, []]);
+                }
+                if (upperSql.includes('INSERT INTO REFRESH_TOKENS')) {
+                    return Promise.resolve([{ affectedRows: 1, insertId: 2 }, []]);
+                }
+                return Promise.resolve([[], []]);
+            });
+
+            const res = await request(app)
+                .post('/api/auth/refresh')
+                .send({ refreshToken: mockRefreshToken });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toHaveProperty('token');
+            expect(res.body).toHaveProperty('refreshToken');
+
+            // Verify old token was deleted
+            const deleteCall = db.query.mock.calls.find(c => c[0] && c[0].toUpperCase().includes('DELETE FROM REFRESH_TOKENS'));
+            expect(deleteCall).toBeDefined();
+            expect(deleteCall[1]).toEqual([mockRefreshToken]);
+        });
+
+        it('should fail with 401 if refresh token is expired', async () => {
+            const mockRefreshToken = 'expired_refresh_token_string';
+            const mockStoredToken = {
+                id: 1,
+                user_id: 101,
+                token: mockRefreshToken,
+                expires_at: new Date(Date.now() - 1000).toISOString() // expired 1s ago
+            };
+
+            db.query.mockImplementation((sql, params) => {
+                const upperSql = sql.trim().toUpperCase();
+                if (upperSql.includes('SELECT * FROM REFRESH_TOKENS WHERE TOKEN = ?')) {
+                    return Promise.resolve([[mockStoredToken], []]);
+                }
+                if (upperSql.includes('DELETE FROM REFRESH_TOKENS WHERE TOKEN = ?')) {
+                    return Promise.resolve([{ affectedRows: 1 }, []]);
+                }
+                return Promise.resolve([[], []]);
+            });
+
+            const res = await request(app)
+                .post('/api/auth/refresh')
+                .send({ refreshToken: mockRefreshToken });
+
+            expect(res.statusCode).toBe(401);
+            expect(res.body.message).toMatch(/expired/i);
+
+            // Verify old token was deleted from database
+            const deleteCall = db.query.mock.calls.find(c => c[0] && c[0].toUpperCase().includes('DELETE FROM REFRESH_TOKENS'));
+            expect(deleteCall).toBeDefined();
+        });
+
+        it('should fail with 401 if refresh token does not exist', async () => {
+            db.query.mockResolvedValue([[], []]);
+
+            const res = await request(app)
+                .post('/api/auth/refresh')
+                .send({ refreshToken: 'non_existent_token' });
+
+            expect(res.statusCode).toBe(401);
+        });
+    });
+
+    describe('Session Revocation (POST /api/auth/revoke)', () => {
+        it('should delete the refresh token from the database', async () => {
+            const mockRefreshToken = 'active_refresh_token_string';
+            db.query.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+            const res = await request(app)
+                .post('/api/auth/revoke')
+                .send({ refreshToken: mockRefreshToken });
+
+            expect(res.statusCode).toBe(200);
+            expect(res.body).toHaveProperty('message', 'Token revoked successfully');
+
+            const deleteCall = db.query.mock.calls.find(c => c[0] && c[0].toUpperCase().includes('DELETE FROM REFRESH_TOKENS'));
+            expect(deleteCall).toBeDefined();
+            expect(deleteCall[1]).toEqual([mockRefreshToken]);
+        });
+    });
+});

--- a/backend/tests/setupDb.js
+++ b/backend/tests/setupDb.js
@@ -168,7 +168,11 @@ async function setupTestDb() {
             'migrations/migration_sprint11_symptom_checker.sql',
             'migrations/migration_sprint11_departments.sql',
             'migrations/migration_sprint12_consent_logs.sql',
-            'migrations/migration_sprint13_abha_support.sql'
+            'migrations/migration_sprint13_abha_support.sql',
+            'migration_advanced_portal.sql',
+            'migration_issue144_medical_data.sql',
+            'migrations/migration_sprint14_capacity_booking.sql',
+            'migrations/migration_sprint15_refresh_tokens.sql'
         ];
 
         for (const file of migrationFiles) {

--- a/frontend/src/services/apiClient.js
+++ b/frontend/src/services/apiClient.js
@@ -5,6 +5,84 @@ import { API, authedHeaders } from '../config/api';
  * Consolidates safeFetch and authedHeaders into a singular interface.
  */
 
+let isRefreshing = false;
+let refreshSubscribers = [];
+
+function subscribeTokenRefresh(cb) {
+    refreshSubscribers.push(cb);
+}
+
+function onRefreshed(token) {
+    refreshSubscribers.forEach(cb => cb(token));
+    refreshSubscribers = [];
+}
+
+function handleAuthFailure() {
+    localStorage.removeItem('hs_token');
+    localStorage.removeItem('hs_refresh_token');
+    localStorage.removeItem('hs_user');
+    window.location.reload();
+}
+
+async function fetchWithRetry(url, options = {}, retries = 1) {
+    let response = await fetch(url, options);
+
+    if (response.status === 401 && !url.includes('/api/auth/login') && !url.includes('/api/auth/refresh') && retries > 0) {
+        const refreshToken = localStorage.getItem('hs_refresh_token');
+        if (!refreshToken) {
+            handleAuthFailure();
+            return response;
+        }
+
+        if (!isRefreshing) {
+            isRefreshing = true;
+            try {
+                const refreshResponse = await fetch(`${API}/api/auth/refresh`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ refreshToken })
+                });
+
+                if (refreshResponse.ok) {
+                    const data = await refreshResponse.json();
+                    localStorage.setItem('hs_token', data.token);
+                    if (data.refreshToken) {
+                        localStorage.setItem('hs_refresh_token', data.refreshToken);
+                    }
+                    isRefreshing = false;
+                    onRefreshed(data.token);
+                } else {
+                    isRefreshing = false;
+                    handleAuthFailure();
+                    return response;
+                }
+            } catch (err) {
+                isRefreshing = false;
+                handleAuthFailure();
+                return response;
+            }
+        }
+
+        const newToken = await new Promise(resolve => {
+            subscribeTokenRefresh(token => {
+                resolve(token);
+            });
+        });
+
+        const newHeaders = {
+            ...options.headers,
+            'Authorization': `Bearer ${newToken}`
+        };
+        const newOptions = {
+            ...options,
+            headers: newHeaders
+        };
+        return await fetch(url, newOptions);
+    }
+
+    return response;
+}
+
 const handleResponse = async (response, defaultValue = []) => {
     if (!response.ok) {
         console.warn(`[API] Failure: ${response.status} ${response.statusText}`);
@@ -28,7 +106,7 @@ const handleResponse = async (response, defaultValue = []) => {
 export const apiClient = {
     async get(endpoint, defaultValue = []) {
         try {
-            const response = await fetch(`${API}${endpoint}`, {
+            const response = await fetchWithRetry(`${API}${endpoint}`, {
                 headers: authedHeaders(),
             });
             return await handleResponse(response, defaultValue);
@@ -40,7 +118,7 @@ export const apiClient = {
 
     async post(endpoint, body, defaultValue = []) {
         try {
-            const response = await fetch(`${API}${endpoint}`, {
+            const response = await fetchWithRetry(`${API}${endpoint}`, {
                 method: 'POST',
                 headers: authedHeaders(true),
                 body: JSON.stringify(body),
@@ -54,7 +132,7 @@ export const apiClient = {
 
     async patch(endpoint, body, defaultValue = []) {
         try {
-            const response = await fetch(`${API}${endpoint}`, {
+            const response = await fetchWithRetry(`${API}${endpoint}`, {
                 method: 'PATCH',
                 headers: authedHeaders(true),
                 body: JSON.stringify(body),
@@ -68,7 +146,7 @@ export const apiClient = {
 
     async delete(endpoint, defaultValue = []) {
         try {
-            const response = await fetch(`${API}${endpoint}`, {
+            const response = await fetchWithRetry(`${API}${endpoint}`, {
                 method: 'DELETE',
                 headers: authedHeaders(),
             });
@@ -81,7 +159,7 @@ export const apiClient = {
 
     async getBlob(endpoint) {
         try {
-            const response = await fetch(`${API}${endpoint}`, {
+            const response = await fetchWithRetry(`${API}${endpoint}`, {
                 headers: authedHeaders(),
             });
             if (!response.ok) throw new Error(`Fetch failed: ${response.status}`);

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -9,6 +9,9 @@ export const authService = {
         
         if (data.token) {
             localStorage.setItem('hs_token', data.token);
+            if (data.refreshToken) {
+                localStorage.setItem('hs_refresh_token', data.refreshToken);
+            }
             // Store minimal session data
             const session = {
                 id: data.id,
@@ -29,6 +32,9 @@ export const authService = {
         
         if (data.token) {
             localStorage.setItem('hs_token', data.token);
+            if (data.refreshToken) {
+                localStorage.setItem('hs_refresh_token', data.refreshToken);
+            }
             const session = {
                 id: data.id,
                 email: data.email,
@@ -48,6 +54,9 @@ export const authService = {
 
         if (data.token) {
             localStorage.setItem('hs_token', data.token);
+            if (data.refreshToken) {
+                localStorage.setItem('hs_refresh_token', data.refreshToken);
+            }
             const session = {
                 id: data.id,
                 email: data.email,
@@ -63,7 +72,14 @@ export const authService = {
      * Clear all session data
      */
     logout() {
+        const refreshToken = localStorage.getItem('hs_refresh_token');
+        if (refreshToken) {
+            apiClient.post('/api/auth/revoke', { refreshToken }).catch(e => {
+                console.error('Failed to revoke token on logout:', e);
+            });
+        }
         localStorage.removeItem('hs_token');
+        localStorage.removeItem('hs_refresh_token');
         localStorage.removeItem('hs_user');
         
         // Comprehensive cleanup of all application-prefixed keys


### PR DESCRIPTION
## Problem
The backend relies entirely on stateless access tokens with an 8-hour expiry. Stolen credentials cannot be revoked, leaving a wide exploit window.

## Proposed Changes
- **Database Schema**: Created the `refresh_tokens` table referencing `users(id) ON DELETE CASCADE` to store active refresh tokens. Added index on the `token` column.
- **Short-Lived Access Tokens**: Reduced default access token lifetime (`jwtExpiresIn`) to 15 minutes in `auth.js`.
- **Token Rotation & Revocation**:
  - Implemented `POST /api/auth/refresh` rotating access and refresh tokens, invalidating the old ones (replay attack prevention).
  - Implemented `POST /api/auth/revoke` (logout) removing refresh tokens from the database to block subsequent refresh attempts.
- **Frontend Interceptor**:
  - Configured `apiClient.js` with `fetchWithRetry` to intercept 401 unauthorized requests, request a new token pair in the background, update the headers, and retry all queued requests.
  - Cleared credentials and forced reload on refresh failure.
  - Revoked refresh tokens upon logout in `authService.js`.
- **Integration Tests**: Added `session.test.js` validating the rotation and revocation endpoints and mock database setup.

Closes #316