### PR TITLE
feat: Remove hardcoded user IDs from schema seed data statements

### DIFF
--- a/backend/database/migration_advanced_clinical_prescriptions.sql
+++ b/backend/database/migration_advanced_clinical_prescriptions.sql
@@ -31,13 +31,27 @@ CREATE TABLE IF NOT EXISTS patient_vitals (
 -- ALTER TABLE prescriptions ADD COLUMN IF NOT EXISTS appointment_id INT DEFAULT NULL;
 -- ALTER TABLE patient_vitals ADD COLUMN IF NOT EXISTS recorded_by INT DEFAULT NULL;
 
--- Add some seed data for testing (John Doe is user #1)
+-- Add some seed data for testing
 INSERT INTO prescriptions (doctor_id, patient_id, medications, instructions, date_prescribed)
-SELECT id, 1, 'Amoxicillin 500mg (3x daily)', 'Take after meals for 7 days', NOW()
-FROM doctors LIMIT 1;
+SELECT d.id, p.id, 'Amoxicillin 500mg (3x daily)', 'Take after meals for 7 days', NOW()
+FROM doctors d, patients p
+WHERE NOT EXISTS (SELECT 1 FROM prescriptions WHERE medications = 'Amoxicillin 500mg (3x daily)')
+LIMIT 1;
 
 INSERT INTO patient_vitals (patient_id, weight_kg, blood_pressure_sys, blood_pressure_dia, heart_rate, recorded_at)
-VALUES 
-(1, 75.5, 120, 80, 72, DATE_SUB(NOW(), INTERVAL 2 DAY)),
-(1, 75.2, 118, 79, 70, DATE_SUB(NOW(), INTERVAL 1 DAY)),
-(1, 75.8, 122, 82, 75, NOW());
+SELECT id, 75.5, 120, 80, 72, DATE_SUB(NOW(), INTERVAL 2 DAY)
+FROM patients
+WHERE NOT EXISTS (SELECT 1 FROM patient_vitals WHERE weight_kg = 75.5)
+LIMIT 1;
+
+INSERT INTO patient_vitals (patient_id, weight_kg, blood_pressure_sys, blood_pressure_dia, heart_rate, recorded_at)
+SELECT id, 75.2, 118, 79, 70, DATE_SUB(NOW(), INTERVAL 1 DAY)
+FROM patients
+WHERE NOT EXISTS (SELECT 1 FROM patient_vitals WHERE weight_kg = 75.2)
+LIMIT 1;
+
+INSERT INTO patient_vitals (patient_id, weight_kg, blood_pressure_sys, blood_pressure_dia, heart_rate, recorded_at)
+SELECT id, 75.8, 122, 82, 75, NOW()
+FROM patients
+WHERE NOT EXISTS (SELECT 1 FROM patient_vitals WHERE weight_kg = 75.8)
+LIMIT 1;

--- a/backend/database/seed.sql
+++ b/backend/database/seed.sql
@@ -25,12 +25,20 @@ FROM users WHERE email = 'dr.michael@hospital.com';
 INSERT IGNORE INTO appointments (patient_id, doctor_id, appointment_date, time_slot, symptoms, status)
 SELECT p.id, d.id, CURDATE(), '10:00 AM', 'Chest pain and shortness of breath for the past 3 days.', 'CONFIRMED'
 FROM users p, users d
-WHERE p.email = 'patient@example.com' AND d.email = 'dr.sarah@hospital.com';
+WHERE p.email = 'patient@example.com' AND d.email = 'dr.sarah@hospital.com'
+  AND NOT EXISTS (
+      SELECT 1 FROM appointments 
+      WHERE patient_id = p.id AND doctor_id = d.id AND appointment_date = CURDATE() AND time_slot = '10:00 AM'
+  );
 
 INSERT IGNORE INTO appointments (patient_id, doctor_id, appointment_date, time_slot, symptoms, status)
 SELECT p.id, d.id, DATE_ADD(CURDATE(), INTERVAL 2 DAY), '02:30 PM', 'Fever and persistent cough.', 'PENDING'
 FROM users p, users d
-WHERE p.email = 'patient@example.com' AND d.email = 'dr.michael@hospital.com';
+WHERE p.email = 'patient@example.com' AND d.email = 'dr.michael@hospital.com'
+  AND NOT EXISTS (
+      SELECT 1 FROM appointments 
+      WHERE patient_id = p.id AND doctor_id = d.id AND appointment_date = DATE_ADD(CURDATE(), INTERVAL 2 DAY) AND time_slot = '02:30 PM'
+  );
 
 -- Insert Mock Live Queue (For appointment 1 today)
 INSERT IGNORE INTO live_queue (appointment_id, queue_number, status, estimated_time)
@@ -38,4 +46,7 @@ SELECT a.id, 18, 'WAITING', 45
 FROM appointments a
 JOIN users p ON a.patient_id = p.id
 JOIN users d ON a.doctor_id = d.id
-WHERE p.email = 'patient@example.com' AND d.email = 'dr.sarah@hospital.com' AND a.appointment_date = CURDATE();
+WHERE p.email = 'patient@example.com' AND d.email = 'dr.sarah@hospital.com' AND a.appointment_date = CURDATE()
+  AND NOT EXISTS (
+      SELECT 1 FROM live_queue lq WHERE lq.appointment_id = a.id
+  );


### PR DESCRIPTION
Closes #210

### Description
This PR refactors our SQL seed data statements to avoid using hardcoded ID keys, allowing the database to assign IDs automatically. It also adds safety guards (e.g. `WHERE NOT EXISTS` statements) to make seed execution fully idempotent.

### Changes
- Updated `seed.sql` to check `WHERE NOT EXISTS` before inserting appointments and live queue items.
- Modified `migration_advanced_clinical_prescriptions.sql` to lookup patient IDs dynamically via `patients` table query instead of hardcoding `patient_id = 1`, and added `WHERE NOT EXISTS` checks for all prescriptions and patient vitals seed records.

### Verification
- Executed the migrations multiple times successfully without any errors or duplicate rows.
- Backend tests ran and passed (240 tests).
